### PR TITLE
Preconnect before issuing HTTP requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/getlantern/kindling
 
 go 1.22.4
 
+replace github.com/getlantern/fronted => ../fronted
+
 require (
 	github.com/Jigsaw-Code/outline-sdk v0.0.18-0.20241106233708-faffebb12629
 	github.com/Jigsaw-Code/outline-sdk/x v0.0.0-20250113162209-efa808309e1e
-	github.com/getlantern/fronted v0.0.0-20250116185732-4ed3a2adcfbd
+	github.com/getlantern/fronted v0.0.0-20250122202701-759a25a3e2d0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ github.com/getlantern/fdcount v0.0.0-20190912142506-f89afd7367c4 h1:JdD4XSaT6/j6
 github.com/getlantern/fdcount v0.0.0-20190912142506-f89afd7367c4/go.mod h1:XZwE+iIlAgr64OFbXKFNCllBwV4wEipPx8Hlo2gZdbM=
 github.com/getlantern/filepersist v0.0.0-20160317154340-c5f0cd24e799 h1:FhkPUYCQYmoxS02r2GRrIV7dahUIncRl36xzs3/mnjA=
 github.com/getlantern/filepersist v0.0.0-20160317154340-c5f0cd24e799/go.mod h1:8DGAx0LNUfXNnEH+fXI0s3OCBA/351kZCiz/8YSK3i8=
-github.com/getlantern/fronted v0.0.0-20250116185732-4ed3a2adcfbd h1:xm75DFK3i7bsfoWHB94bV+FswmSwM71HL8OBgGGVj24=
-github.com/getlantern/fronted v0.0.0-20250116185732-4ed3a2adcfbd/go.mod h1:66ePVEpsOGseZtSIMNnTD8uC9kuVcSxEmc7UH4zpnqY=
 github.com/getlantern/golog v0.0.0-20190830074920-4ef2e798c2d7/go.mod h1:zx/1xUUeYPy3Pcmet8OSXLbF47l+3y6hIPpyLWoR9oc=
 github.com/getlantern/golog v0.0.0-20210606115803-bce9f9fe5a5f/go.mod h1:ZyIjgH/1wTCl+B+7yH1DqrWp6MPJqESmwmEQ89ZfhvA=
 github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 h1:NlQedYmPI3pRAXJb+hLVVDGqfvvXGRPV8vp7XOjKAZ0=

--- a/kindling_test.go
+++ b/kindling_test.go
@@ -1,6 +1,84 @@
 package kindling
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestLantern(t *testing.T) {
+	k := NewKindling(
+		//WithDomainFronting("https://media.githubusercontent.com/media/getlantern/fronted/refs/heads/main/fronted.yaml.gz", ""),
+		WithProxyless("config.getiantem.org"),
+	)
+	client := k.NewHTTPClient()
+	r, err := newRequestWithHeaders(context.Background(), "POST", "https://config.getiantem.org:443/proxies.yaml.gz", http.NoBody)
+	if err != nil {
+		t.Fatalf("newRequestWithHeaders() = %v; want nil", err)
+	}
+	fmt.Printf("Request: %v\n", r)
+	res, err := client.Do(r)
+	if err != nil {
+		t.Fatalf("client.Post() = %v; want nil", err)
+	}
+	defer res.Body.Close()
+	// Print the response
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("io.ReadAll() = %v; want nil", err)
+	}
+	fmt.Printf("Response: %s", body)
+
+	// Print the response headers
+	for k, v := range res.Header {
+		fmt.Printf("%s: %s\n", k, v)
+	}
+	//t.Logf("Response: %s", body)
+
+}
+
+const (
+	// Required common headers to send to the proxy server.
+	appVersionHeader = "X-Lantern-App-Version"
+	versionHeader    = "X-Lantern-Version"
+	platformHeader   = "X-Lantern-Platform"
+	appNameHeader    = "X-Lantern-App"
+	deviceIdHeader   = "X-Lantern-Device-Id"
+	userIdHeader     = "X-Lantern-User-Id"
+)
+
+const (
+	AppName = "kindling"
+
+	// Placeholders to use in the request headers.
+	ClientVersion = "7.6.47"
+	Version       = "7.6.47"
+
+	Platform = "linux"
+	DeviceId = "some-uuid-here"
+
+	// userId and proToken will be set to actual values when user management is implemented.
+	UserId   = "23409" // set to specific value so the server returns a desired config.
+	ProToken = ""
+)
+
+// newRequestWithHeaders creates a new [http.Request] with the required headers.
+func newRequestWithHeaders(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	// add required headers. Currently, all but the auth token are placeholders.
+	req.Header.Set(appVersionHeader, ClientVersion)
+	req.Header.Set(versionHeader, Version)
+	req.Header.Set(userIdHeader, UserId)
+	req.Header.Set(platformHeader, Platform)
+	req.Header.Set(appNameHeader, AppName)
+	req.Header.Set(deviceIdHeader, DeviceId)
+	return req, nil
+}
 
 func TestKindling(t *testing.T) {
 	t.Parallel()

--- a/race_transport.go
+++ b/race_transport.go
@@ -2,24 +2,26 @@ package kindling
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync/atomic"
 	"time"
 )
 
 type raceTransport struct {
-	roundTrippers []http.RoundTripper
+	httpDialers []httpDialer
 }
 
-func newRaceTransport(roundTrippers ...http.RoundTripper) http.RoundTripper {
+func newRaceTransport(httpDialers ...httpDialer) http.RoundTripper {
 	return &raceTransport{
-		roundTrippers: roundTrippers,
+		httpDialers: httpDialers,
 	}
 }
 
 func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Try all RoundTrippers in parallel and return the first successful response.
+	// Try all methods in parallel and return the first successful response.
 	// If all fail, return the last error.
 	ctx, cancel := context.WithTimeout(req.Context(), 1*time.Minute)
 
@@ -27,36 +29,43 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// canceling any other in-flight requests that respect the context (which they should).
 	defer cancel()
 	var httpErrors atomic.Int64
-	var responses atomic.Int64
-	var respCh = make(chan *http.Response)
+	var roundTrippherCh = make(chan http.RoundTripper)
 	var errCh = make(chan error)
-	for _, rt := range t.roundTrippers {
-		go func(rt http.RoundTripper, r *http.Request) {
-			resp, err := rt.RoundTrip(r)
-			if resp != nil {
-				fmt.Printf("Response: %s", resp.Header)
-			}
+	for _, d := range t.httpDialers {
+		go func(d httpDialer) {
+			// We first create connected http.RoundTrippers prior to sending the request.
+			// With this method, we don't have to worry about the idempotency of the request
+			// because we ultimately try the connections serially in the next step.
+			connectedRoundTripper, err := d(ctx, req.URL.Host)
 			if err != nil {
-				if httpErrors.Add(1) == int64(len(t.roundTrippers)) {
-					errCh <- err
+				if httpErrors.Add(1) == int64(len(t.httpDialers)) {
+					errCh <- fmt.Errorf("failed to connect to any dialer with last error: %v", err)
 				}
 			} else {
-				if responses.Add(1) == 1 {
-					respCh <- resp
-				} else {
-					_ = resp.Body.Close()
-				}
+				roundTrippherCh <- connectedRoundTripper
 			}
-		}(rt, req.Clone(ctx))
+		}(d)
 	}
-	select {
-	case resp := <-respCh:
-		// If we get a response, we can cancel the other requests.
-		cancel()
-		return resp, nil
-	case err := <-errCh:
-		return nil, err
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	// Select up to the first response or error, or until we've hit the target number of tries or the context is canceled.
+	retryTimes := 3
+	for i := 0; i < retryTimes; i++ {
+		select {
+		case roundTripper := <-roundTrippherCh:
+			// If we get a connection, try to send the request.
+			resp, err := roundTripper.RoundTrip(req)
+			// If the request fails, close the connection and return the error.
+			if err != nil {
+				slog.Error("HTTP request failed", "error", err)
+				continue
+			}
+
+			cancel()
+			return resp, nil
+		case err := <-errCh:
+			return nil, err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
+	return nil, errors.New("failed to get response")
 }


### PR DESCRIPTION
This change preconnects in parallel to all circumvention methods before issuing HTTP requests serially. This prevents idempotency issues with the HTTP requests potentially modifying data on the server, as only one request should succeed.