### PR TITLE
Added app name headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The idea is to continually add more techniques as they become available such tha
 
 ```go
 k := kindling.NewKindling(
+	"myapp",
     kindling.WithDomainFronting("https://raw.githubusercontent.com/getlantern/fronted/refs/heads/main/fronted.yaml.gz"),
     kindling.WithProxyless("raw.githubusercontent.com"),
     kindling.WithDNSTunnel(newDNSTT()),

--- a/kindling.go
+++ b/kindling.go
@@ -37,6 +37,7 @@ type kindling struct {
 	roundTripperGenerators []roundTripperGenerator
 	logWriter              io.Writer
 	panicListener          func(string)
+	appName                string // The name of the tool using kindling, used for logging and debugging.
 }
 
 // Make sure that kindling implements the Kindling interface.
@@ -55,10 +56,12 @@ type Option interface {
 	priority() int
 }
 
-// NewKindling returns a new Kindling.
-func NewKindling(options ...Option) Kindling {
+// NewKindling returns a new Kindling with the specified name of your tool and the options to use for
+// accessing control plane data.
+func NewKindling(name string, options ...Option) Kindling {
 	k := &kindling{
 		logWriter: os.Stdout,
+		appName:   name,
 	}
 
 	// Sort the options by priority in case some options depend on others.
@@ -146,7 +149,7 @@ func WithPanicListener(panicListener func(string)) Option {
 
 func (k *kindling) newRaceTransport() http.RoundTripper {
 	// Now create a RoundTripper that races between the available options.
-	return newRaceTransport(k.panicListener, k.roundTripperGenerators...)
+	return newRaceTransport(k.appName, k.panicListener, k.roundTripperGenerators...)
 }
 
 func newSmartHTTPDialerFunc(logWriter io.Writer, domains ...string) (roundTripperGenerator, error) {

--- a/kindling_test.go
+++ b/kindling_test.go
@@ -18,7 +18,7 @@ func TestNewKindling(t *testing.T) {
 
 		f := fronted.NewFronted(
 			fronted.WithConfigURL("https://media.githubusercontent.com/media/getlantern/fronted/refs/heads/main/fronted.yaml.gz"))
-		kindling := NewKindling(
+		kindling := NewKindling("kindling",
 			WithDomainFronting(f),
 			WithPanicListener(func(string) {}),
 		)
@@ -29,7 +29,7 @@ func TestNewKindling(t *testing.T) {
 }
 
 func TestLantern(t *testing.T) {
-	k := NewKindling(
+	k := NewKindling("kindling",
 		//WithDomainFronting("https://media.githubusercontent.com/media/getlantern/fronted/refs/heads/main/fronted.yaml.gz", ""),
 		WithProxyless("config.getiantem.org"),
 	)
@@ -109,7 +109,7 @@ func TestKindling(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			t.Parallel()
 
-			kindling := NewKindling()
+			kindling := NewKindling("kindling")
 			if kindling == nil {
 				t.Errorf("NewKindling() = nil; want non-nil Kindling")
 			}
@@ -122,7 +122,7 @@ func TestKindling(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			t.Parallel()
 
-			kindling := NewKindling()
+			kindling := NewKindling("kindling")
 			httpClient := kindling.NewHTTPClient()
 			if httpClient == nil {
 				t.Errorf("kindling.NewHTTPClient() = nil; want non-nil *http.Client")

--- a/race_transport_test.go
+++ b/race_transport_test.go
@@ -12,7 +12,7 @@ func TestCloneRequest_NilBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
 	}
-	cloned := cloneRequest(req)
+	cloned := cloneRequest(req, "test", "test")
 	if cloned == req {
 		t.Error("expected a new request, got the same pointer")
 	}
@@ -26,7 +26,7 @@ func TestCloneRequest_NoBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
 	}
-	cloned := cloneRequest(req)
+	cloned := cloneRequest(req, "test", "test")
 	if cloned == req {
 		t.Error("expected a new request, got the same pointer")
 	}
@@ -41,7 +41,7 @@ func TestCloneRequest_WithBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
 	}
-	cloned := cloneRequest(req)
+	cloned := cloneRequest(req, "test", "test")
 
 	// Both bodies should be readable and equal to originalBody
 	origBodyBytes, err := io.ReadAll(req.Body)
@@ -68,7 +68,7 @@ func TestCloneRequest_BodyReadError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
 	}
-	cloned := cloneRequest(req)
+	cloned := cloneRequest(req, "test", "test")
 	// Should return the original request if error occurs
 	if cloned != req {
 		t.Error("expected cloneRequest to return original request on error")


### PR DESCRIPTION
Require an app name and add headers for the app name and the method being used.

This pull request introduces a new `appName` field to the `kindling` struct, which is used for logging and debugging purposes. It updates the `NewKindling` function to require this `appName` parameter and propagates the changes across the codebase, including tests and the `raceTransport` implementation. Additionally, the `cloneRequest` function now includes custom headers to track the application and method used.

### Enhancements to `kindling` initialization:

* [`kindling.go`](diffhunk://#diff-6b0f41a9a52c4516297a0a7d67b2a60f85783f9cc33b6234dc32e5759f1118deR40): Added an `appName` field to the `kindling` struct for logging/debugging and updated the `NewKindling` function to require an `appName` parameter. The `newRaceTransport` function now passes the `appName` to the `raceTransport` constructor. [[1]](diffhunk://#diff-6b0f41a9a52c4516297a0a7d67b2a60f85783f9cc33b6234dc32e5759f1118deR40) [[2]](diffhunk://#diff-6b0f41a9a52c4516297a0a7d67b2a60f85783f9cc33b6234dc32e5759f1118deL58-R64) [[3]](diffhunk://#diff-6b0f41a9a52c4516297a0a7d67b2a60f85783f9cc33b6234dc32e5759f1118deL149-R152)

### Updates to `raceTransport`:

* [`race_transport.go`](diffhunk://#diff-627643b178443a85b032f7873962ed96289a4f57cff5a4737f67c25c23bb2342R18-R21): Updated the `raceTransport` struct to include the `appName` field. Modified the `RoundTrip` and `connectedRoundTripper` methods to use a new `namedRoundTripper` type and include the `appName` in HTTP headers via the updated `cloneRequest` function. [[1]](diffhunk://#diff-627643b178443a85b032f7873962ed96289a4f57cff5a4737f67c25c23bb2342R18-R21) [[2]](diffhunk://#diff-627643b178443a85b032f7873962ed96289a4f57cff5a4737f67c25c23bb2342R30-R38) [[3]](diffhunk://#diff-627643b178443a85b032f7873962ed96289a4f57cff5a4737f67c25c23bb2342L41-R48) [[4]](diffhunk://#diff-627643b178443a85b032f7873962ed96289a4f57cff5a4737f67c25c23bb2342L67-R74) [[5]](diffhunk://#diff-627643b178443a85b032f7873962ed96289a4f57cff5a4737f67c25c23bb2342L83-R90) [[6]](diffhunk://#diff-627643b178443a85b032f7873962ed96289a4f57cff5a4737f67c25c23bb2342L110-R128)

### Enhancements to request cloning:

* [`race_transport.go`](diffhunk://#diff-627643b178443a85b032f7873962ed96289a4f57cff5a4737f67c25c23bb2342L110-R128): Updated the `cloneRequest` function to add `X-Kindling-App` and `X-Kindling-Method` headers to cloned HTTP requests for better traceability.

### Test updates:

* `kindling_test.go` and `race_transport_test.go`: Updated all relevant test cases to include the `appName` parameter when calling `NewKindling` or `cloneRequest`. This ensures compatibility with the new function signatures and validates the added functionality. [[1]](diffhunk://#diff-7cc4f5a53efba11254f8e94b47b27be6990a77d03fe15eddfae8ccd104b97d40L21-R21) [[2]](diffhunk://#diff-7cc4f5a53efba11254f8e94b47b27be6990a77d03fe15eddfae8ccd104b97d40L32-R32) [[3]](diffhunk://#diff-7cc4f5a53efba11254f8e94b47b27be6990a77d03fe15eddfae8ccd104b97d40L112-R112) [[4]](diffhunk://#diff-7cc4f5a53efba11254f8e94b47b27be6990a77d03fe15eddfae8ccd104b97d40L125-R125) [[5]](diffhunk://#diff-4327c83d5df3648f60c5bdfaeed5501643aa919904e2bba93f61e7fa853f7261L15-R15) [[6]](diffhunk://#diff-4327c83d5df3648f60c5bdfaeed5501643aa919904e2bba93f61e7fa853f7261L29-R29) [[7]](diffhunk://#diff-4327c83d5df3648f60c5bdfaeed5501643aa919904e2bba93f61e7fa853f7261L44-R44) [[8]](diffhunk://#diff-4327c83d5df3648f60c5bdfaeed5501643aa919904e2bba93f61e7fa853f7261L71-R71)