### PR TITLE
Rewrite kindling and race transport

### DIFF
--- a/kindling.go
+++ b/kindling.go
@@ -101,6 +101,9 @@ func (k *kindling) NewHTTPClient() *http.Client {
 
 // ReplaceTransport swaps the round-tripper generator for the named transport.
 func (k *kindling) ReplaceTransport(name string, rt func(ctx context.Context, addr string) (http.RoundTripper, error)) error {
+	if rt == nil {
+		return fmt.Errorf("round-tripper generator is nil")
+	}
 	k.mu.Lock()
 	defer k.mu.Unlock()
 	for i, tr := range k.transports {
@@ -124,6 +127,9 @@ func (k *kindling) ReplaceTransport(name string, rt func(ctx context.Context, ad
 // options like WithProxyless.
 func WithLogWriter(w io.Writer) Option {
 	return func(k *kindling) error {
+		if w == nil {
+			return fmt.Errorf("log writer is nil")
+		}
 		k.logWriter = w
 		k.log = slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{
 			AddSource: true,

--- a/kindling.go
+++ b/kindling.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"sort"
 	"sync"
 	"time"
 
@@ -20,330 +19,277 @@ import (
 	"github.com/getlantern/fronted"
 )
 
-var log = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}))
-
-// Kindling is the interface that wraps the basic Dial and DialContext methods for control
-// plane traffic.
+// Kindling creates HTTP clients that race requests across multiple censorship
+// circumvention transports, returning the first successful response.
 type Kindling interface {
-	// NewHTTPClient returns a new HTTP client that is configured to use kindling.
+	// NewHTTPClient returns an HTTP client whose transport races all configured
+	// circumvention transports in parallel.
 	NewHTTPClient() *http.Client
-	// ReplaceTransport replaces an existing transport RoundTripper generator with the provided one.
+
+	// ReplaceTransport swaps the round-tripper generator for the named transport,
+	// preserving its MaxLength and IsStreamable properties.
 	ReplaceTransport(name string, rt func(ctx context.Context, addr string) (http.RoundTripper, error)) error
 }
-type roundTripperGenerator func(ctx context.Context, addr string) (http.RoundTripper, error)
 
-//type httpDialer func(ctx context.Context, addr string) (http.RoundTripper, error)
-
-type kindling struct {
-	roundTripperGeneratorsMutex sync.Mutex
-	transports                  []Transport
-	logWriter                   io.Writer
-	panicListener               func(string)
-	appName                     string // The name of the tool using kindling, used for logging and debugging.
-}
-
-// Make sure that kindling implements the Kindling interface.
-var _ Kindling = &kindling{}
-
-// Create an enum of priority levels for options where the priority matters (things like panic listeners
-// that need to be set before other options).
-const (
-	priorityLogWriter = iota
-	priorityPanicListener
-)
-
-// Option is a functional option type that allows us to configure the Client.
-type Option interface {
-	apply(*kindling)
-	priority() int
-}
-
-// NewKindling returns a new Kindling with the specified name of your tool and the options to use for
-// accessing control plane data.
-func NewKindling(name string, options ...Option) Kindling {
-	k := &kindling{
-		logWriter: os.Stdout,
-		appName:   name,
-	}
-
-	// Sort the options by priority in case some options depend on others.
-	sort.Sort(byPriority(options))
-
-	// Apply all the functional options to configure the client.
-	for _, opt := range options {
-		opt.apply(k)
-	}
-	return k
-}
-
-// NewHTTPClient implements the Kindling interface.
-func (k *kindling) NewHTTPClient() *http.Client {
-	// Create a specialized HTTP transport that concurrently races between fronted and smart dialer.
-	// All options are tried in parallel and the first one to succeed is used.
-	// If all options fail, the last error is returned.
-	return &http.Client{
-		Transport: k.newRaceTransport(),
-	}
-}
-
-func (k *kindling) ReplaceTransport(name string, rt func(ctx context.Context, addr string) (http.RoundTripper, error)) error {
-	k.roundTripperGeneratorsMutex.Lock()
-	defer k.roundTripperGeneratorsMutex.Unlock()
-
-	for i, tr := range k.transports {
-		slog.Info("Checking transport", "name", tr.Name())
-		if tr.Name() == name {
-			k.transports[i] = newTransport(name, tr.MaxLength(), tr.IsStreamable(), rt)
-			return nil
-		}
-	}
-	return fmt.Errorf("Could not find matching transport: %v", name)
-}
-
-// WithDomainFronting is a functional option that sets up domain fronting for kindling using
-// the provided fronted.Fronted instance from https://github.com/getlantern/fronted.
-func WithDomainFronting(f fronted.Fronted) Option {
-	log.Info("Setting domain fronting")
-	if f == nil {
-		log.Error("Fronted instance is nil")
-		return &emptyOption{}
-	}
-	return WithTransport(newTransport("fronted", 0, true, func(ctx context.Context, addr string) (http.RoundTripper, error) {
-		return f.NewConnectedRoundTripper(ctx, addr)
-	}))
-}
-
-// WithDNSTunnel is a functional option that sets up a DNS tunnel for kindling using the provided
-// [dnstt.DNSTT] instance
-func WithDNSTunnel(d dnstt.DNSTT) Option {
-	log.Info("Setting DNS tunnel")
-	if d == nil {
-		log.Error("DNSTT instance is nil")
-		return &emptyOption{}
-	}
-	return WithTransport(newTransport("dnstt", 0, true, func(ctx context.Context, addr string) (http.RoundTripper, error) {
-		return d.NewRoundTripper(ctx, addr)
-	}))
-}
-
-// WithAMPCache uses the AMP cache for making requests. It adds an 'amp' round tripper from the provided amp.Client.
-func WithAMPCache(c amp.Client) Option {
-	log.Info("Setting AMP cache")
-	if c == nil {
-		log.Error("AMP client is nil")
-		return &emptyOption{}
-	}
-	return WithTransport(newTransport("amp", 6000, false, func(ctx context.Context, addr string) (http.RoundTripper, error) {
-		return c.RoundTripper()
-	}))
-}
-
-// WithProxyless is a functional option that enables proxyless mode for the Kindling such that
-// it accesses the control plane directly using a variety of proxyless techniques.
-func WithProxyless(domains ...string) Option {
-	return newOption(func(k *kindling) {
-		slog.Info("Setting proxyless mode")
-		smartDialer, err := newSmartHTTPDialerFunc(k.logWriter, domains...)
-		if err != nil {
-			log.Error("Failed to create smart dialer", "error", err)
-			return
-		}
-		k.transports = append(k.transports, newTransport("smart", 0, true, smartDialer))
-	})
-}
-
-// WithLogWriter is a functional option that sets the log writer for the Kindling.
-// By default, the log writer is set to os.Stdout.
-// This should be the first option to be applied to the Kindling to ensure that all logs are captured.
-func WithLogWriter(w io.Writer) Option {
-	return newOptionWithPriority(func(k *kindling) {
-		k.logWriter = w
-		log = slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{
-			AddSource: true,
-			Level:     slog.LevelDebug, // Set the log level to debug for detailed output
-		}))
-	}, priorityLogWriter)
-}
-
-// Transport provides the basic interface that any transport must implement to be used by Kindling.
+// Transport defines a censorship circumvention transport that can be used by Kindling.
 type Transport interface {
-	// NewRoundTripper creates a new http.RoundTripper that uses this transport. As much as possible
-	// the RoundTripper should be pre-connected when it is returned, as otherwise it can take too
-	// much time away from other transports. In other words, Kindling parallelizes the connection
-	// of the transports, but the actual sending of the request is done serially to avoid
-	// issues with non-idempotent requests.
+	// NewRoundTripper creates a pre-connected http.RoundTripper. Implementations
+	// should complete the connection before returning so that the race transport
+	// can try requests serially without paying connection latency.
 	NewRoundTripper(ctx context.Context, addr string) (http.RoundTripper, error)
 
-	// MaxLength returns the maximum length of data that can be sent using this transport, if any.
-	// A value of 0 means there is no limit.
+	// MaxLength returns the maximum request body size this transport supports.
+	// Zero means no limit.
 	MaxLength() int
 
-	// IsStreamable returns if the transport support streaming
+	// IsStreamable reports whether this transport supports streaming responses
+	// (e.g. text/event-stream).
 	IsStreamable() bool
 
-	// Name returns the name of the transport for logging and debugging purposes.
+	// Name identifies this transport for logging and debugging.
 	Name() string
 }
 
-// WithTransport allows users to add any transport matching the minimal Transport interface.
-func WithTransport(transport Transport) Option {
-	return newOption(func(k *kindling) {
-		log.Info("Setting custom transport")
-		if transport == nil {
-			log.Error("Transport instance is nil")
-			return
-		}
-		k.transports = append(k.transports, transport)
-	})
+// Option configures a Kindling instance. Options are applied in the order
+// provided — specify WithLogWriter first to capture logs from subsequent
+// transport initialization.
+type Option func(*kindling) error
+
+type kindling struct {
+	mu            sync.Mutex
+	log           *slog.Logger
+	logWriter     io.Writer
+	transports    []Transport
+	panicListener func(string)
+	appName       string
 }
 
-// WithPanicListener is a functional option that sets a panic listener that should be notified
-// whenever any goroutine panics. We set this with a higher priority so that it is set before
-// any other options that may depend on it.
-func WithPanicListener(panicListener func(string)) Option {
-	return newOptionWithPriority(func(k *kindling) {
-		log.Info("Setting panic listener")
-		k.panicListener = panicListener
-	}, priorityPanicListener) // Set the priority to 0 so that it is set before any other options.
-}
+var _ Kindling = (*kindling)(nil)
 
-func (k *kindling) newRaceTransport() http.RoundTripper {
-	// Now create a RoundTripper that races between the available options.
-	return newRaceTransport(k.appName, k.panicListener, k.transports...)
-}
-
-func newSmartHTTPDialerFunc(logWriter io.Writer, domains ...string) (roundTripperGenerator, error) {
-	d, err := newSmartDialer(logWriter, domains...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create smart dialer: %v", err)
+// NewKindling creates a Kindling instance with the given application name and
+// options. Returns an error if any option fails (e.g. a nil transport argument
+// or a failed smart dialer initialization).
+func NewKindling(name string, options ...Option) (Kindling, error) {
+	k := &kindling{
+		appName:   name,
+		logWriter: os.Stdout,
+		log:       slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true})),
 	}
-	return func(ctx context.Context, addr string) (http.RoundTripper, error) {
-		streamConn, err := d.DialStream(ctx, addr)
+	for _, opt := range options {
+		if err := opt(k); err != nil {
+			return nil, fmt.Errorf("kindling: %w", err)
+		}
+	}
+	if k.panicListener == nil {
+		k.panicListener = func(msg string) { k.log.Error(msg) }
+	}
+	return k, nil
+}
+
+// NewHTTPClient returns an HTTP client that races all configured transports.
+// Safe to call concurrently with ReplaceTransport.
+func (k *kindling) NewHTTPClient() *http.Client {
+	k.mu.Lock()
+	snapshot := make([]Transport, len(k.transports))
+	copy(snapshot, k.transports)
+	k.mu.Unlock()
+
+	return &http.Client{
+		Transport: newRaceTransport(k.appName, k.log, k.panicListener, snapshot),
+	}
+}
+
+// ReplaceTransport swaps the round-tripper generator for the named transport.
+func (k *kindling) ReplaceTransport(name string, rt func(ctx context.Context, addr string) (http.RoundTripper, error)) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	for i, tr := range k.transports {
+		if tr.Name() == name {
+			k.transports[i] = &namedTransport{
+				name:         name,
+				maxLength:    tr.MaxLength(),
+				isStreamable: tr.IsStreamable(),
+				newRT:        rt,
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("transport %q not found", name)
+}
+
+// --- Options ---
+
+// WithLogWriter sets the log output destination. By default, logs go to
+// os.Stdout. Specify this first to capture initialization logs from other
+// options like WithProxyless.
+func WithLogWriter(w io.Writer) Option {
+	return func(k *kindling) error {
+		k.logWriter = w
+		k.log = slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{
+			AddSource: true,
+			Level:     slog.LevelDebug,
+		}))
+		return nil
+	}
+}
+
+// WithPanicListener sets a callback invoked when a transport goroutine panics.
+func WithPanicListener(fn func(string)) Option {
+	return func(k *kindling) error {
+		k.panicListener = fn
+		return nil
+	}
+}
+
+// WithTransport adds a custom Transport implementation.
+func WithTransport(t Transport) Option {
+	return func(k *kindling) error {
+		if t == nil {
+			return fmt.Errorf("transport is nil")
+		}
+		k.transports = append(k.transports, t)
+		return nil
+	}
+}
+
+// WithDomainFronting adds domain fronting via the provided fronted.Fronted.
+func WithDomainFronting(f fronted.Fronted) Option {
+	return func(k *kindling) error {
+		if f == nil {
+			return fmt.Errorf("fronted instance is nil")
+		}
+		k.transports = append(k.transports, &namedTransport{
+			name:         "fronted",
+			isStreamable: true,
+			newRT:        f.NewConnectedRoundTripper,
+		})
+		return nil
+	}
+}
+
+// WithDNSTunnel adds DNS tunneling via the provided dnstt.DNSTT.
+func WithDNSTunnel(d dnstt.DNSTT) Option {
+	return func(k *kindling) error {
+		if d == nil {
+			return fmt.Errorf("dnstt instance is nil")
+		}
+		k.transports = append(k.transports, &namedTransport{
+			name:         "dnstt",
+			isStreamable: true,
+			newRT:        d.NewRoundTripper,
+		})
+		return nil
+	}
+}
+
+// WithAMPCache adds AMP caching via the provided amp.Client.
+// AMP has a 6000-byte request body limit and does not support streaming.
+func WithAMPCache(c amp.Client) Option {
+	return func(k *kindling) error {
+		if c == nil {
+			return fmt.Errorf("amp client is nil")
+		}
+		k.transports = append(k.transports, &namedTransport{
+			name:      "amp",
+			maxLength: 6000,
+			newRT: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+				return c.RoundTripper()
+			},
+		})
+		return nil
+	}
+}
+
+// WithProxyless enables direct access using the Outline SDK smart dialer,
+// which bypasses DNS-based and SNI-based blocking.
+func WithProxyless(domains ...string) Option {
+	return func(k *kindling) error {
+		dialer, err := newSmartDialer(k.logWriter, domains...)
 		if err != nil {
-			return nil, fmt.Errorf("failed to dial stream in smart dialer: %v", err)
+			return fmt.Errorf("creating smart dialer: %w", err)
 		}
-		return newTransportWithDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return streamConn, nil
-		}), nil
-	}, nil
-}
-
-// NewSmartHTTPTransport creates a new HTTP transport that uses the Outline smart dialer to dial to the
-// specified domains.
-func NewSmartHTTPTransport(logWriter io.Writer, domains ...string) (*http.Transport, error) {
-	d, err := newSmartDialer(logWriter, domains...)
-	if err != nil {
-		log.Error("Failed to create smart dialer", "error", err)
-		return nil, fmt.Errorf("failed to create smart dialer: %v", err)
-	}
-	return newTransportWithDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {
-		streamConn, err := d.DialStream(ctx, addr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to dial stream: %v", err)
-		}
-		return streamConn, nil
-	}), nil
-}
-
-func newTransportWithDialContext(dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) *http.Transport {
-	return &http.Transport{
-		DialContext:           dialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   20 * time.Second,
-		ExpectContinueTimeout: 4 * time.Second,
+		k.transports = append(k.transports, &namedTransport{
+			name:         "smart",
+			isStreamable: true,
+			newRT: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+				conn, err := dialer.DialStream(ctx, addr)
+				if err != nil {
+					return nil, fmt.Errorf("smart dial: %w", err)
+				}
+				return preconnectedTransport(conn), nil
+			},
+		})
+		return nil
 	}
 }
+
+// --- Internal transport type ---
+
+type namedTransport struct {
+	name         string
+	maxLength    int
+	isStreamable bool
+	newRT        func(ctx context.Context, addr string) (http.RoundTripper, error)
+}
+
+func (t *namedTransport) Name() string       { return t.name }
+func (t *namedTransport) MaxLength() int     { return t.maxLength }
+func (t *namedTransport) IsStreamable() bool { return t.isStreamable }
+
+func (t *namedTransport) NewRoundTripper(ctx context.Context, addr string) (http.RoundTripper, error) {
+	return t.newRT(ctx, addr)
+}
+
+// --- Smart dialer ---
 
 //go:embed smart_dialer_config.yml
-var embedFS embed.FS
+var configFS embed.FS
 
 func newSmartDialer(logWriter io.Writer, domains ...string) (transport.StreamDialer, error) {
+	configBytes, err := configFS.ReadFile("smart_dialer_config.yml")
+	if err != nil {
+		return nil, fmt.Errorf("reading smart dialer config: %w", err)
+	}
 	finder := &smart.StrategyFinder{
 		TestTimeout:  5 * time.Second,
 		LogWriter:    logWriter,
 		StreamDialer: &transport.TCPDialer{},
 		PacketDialer: &transport.UDPDialer{},
 	}
+	return finder.NewDialer(context.Background(), domains, configBytes)
+}
 
-	configBytes, err := embedFS.ReadFile("smart_dialer_config.yml")
+// preconnectedTransport creates an http.Transport that uses an already-established
+// connection. Intended for single-request use within the race transport.
+func preconnectedTransport(conn net.Conn) *http.Transport {
+	return &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return conn, nil
+		},
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:  20 * time.Second,
+		ExpectContinueTimeout: 4 * time.Second,
+	}
+}
+
+// NewSmartHTTPTransport creates an http.Transport using the Outline SDK smart
+// dialer for the given domains. This is a standalone utility that does not
+// require a Kindling instance.
+func NewSmartHTTPTransport(logWriter io.Writer, domains ...string) (*http.Transport, error) {
+	dialer, err := newSmartDialer(logWriter, domains...)
 	if err != nil {
-		log.Error("Failed to read smart dialer config", "error", err)
 		return nil, err
 	}
-	dialer, err := finder.NewDialer(context.Background(), domains, configBytes)
-	if err != nil {
-		log.Error("Failed to create smart dialer", "error", err)
-		return nil, err
-	}
-	return dialer, nil
-}
-
-type option struct {
-	priorityInt int
-	applyFunc   func(*kindling)
-}
-
-func (o *option) apply(k *kindling) {
-	o.applyFunc(k)
-}
-
-func (o *option) priority() int {
-	return o.priorityInt
-}
-
-// Sometimes we need an option to be set prior to other options that depend on it, so we
-// set the priority and store the options prior to executing them.
-func newOptionWithPriority(apply func(*kindling), priority int) Option {
-	return &option{applyFunc: apply, priorityInt: priority}
-}
-
-func newOption(apply func(*kindling)) Option {
-	return &option{applyFunc: apply, priorityInt: 1000}
-}
-
-// byPriority is a type that implements the sort interface for options so that
-// we can apply some options before others that may depend on them.
-type byPriority []Option
-
-func (bp byPriority) Len() int           { return len(bp) }
-func (bp byPriority) Less(i, j int) bool { return bp[i].priority() < bp[j].priority() }
-func (bp byPriority) Swap(i, j int)      { bp[i], bp[j] = bp[j], bp[i] }
-
-type emptyOption struct{}
-
-func (o *emptyOption) apply(k *kindling) {}
-func (o *emptyOption) priority() int     { return 0 }
-
-type namedTransport struct {
-	name         string
-	maxLength    int
-	isStreamable bool
-	rtg          roundTripperGenerator
-}
-
-func (t *namedTransport) NewRoundTripper(ctx context.Context, addr string) (http.RoundTripper, error) {
-	return t.rtg(ctx, addr)
-}
-
-func (t *namedTransport) MaxLength() int {
-	return t.maxLength
-}
-
-func (t *namedTransport) IsStreamable() bool {
-	return t.isStreamable
-}
-
-func (t *namedTransport) Name() string {
-	return t.name
-}
-
-func newTransport(name string, maxLength int, isStreamable bool, rtg roundTripperGenerator) Transport {
-	return &namedTransport{
-		name:         name,
-		maxLength:    maxLength,
-		isStreamable: isStreamable,
-		rtg:          rtg,
-	}
+	return &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialer.DialStream(ctx, addr)
+		},
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:  20 * time.Second,
+		ExpectContinueTimeout: 4 * time.Second,
+	}, nil
 }

--- a/kindling_test.go
+++ b/kindling_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -65,6 +66,9 @@ func TestNewKindling(t *testing.T) {
 }
 
 func TestLantern(t *testing.T) {
+	if os.Getenv("KINDLING_INTEGRATION") == "" {
+		t.Skip("skipping integration test; set KINDLING_INTEGRATION=1 to run")
+	}
 	k, err := NewKindling("kindling",
 		WithProxyless("config.getiantem.org"),
 	)

--- a/kindling_test.go
+++ b/kindling_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/getlantern/fronted"
@@ -18,50 +19,76 @@ func TestNewKindling(t *testing.T) {
 
 		f := fronted.NewFronted(
 			fronted.WithConfigURL("https://media.githubusercontent.com/media/getlantern/fronted/refs/heads/main/fronted.yaml.gz"))
-		kindling := NewKindling("kindling",
+		k, err := NewKindling("kindling",
 			WithDomainFronting(f),
 			WithPanicListener(func(string) {}),
 		)
-		if kindling == nil {
-			t.Errorf("NewKindling() = nil; want non-nil Kindling")
+		if err != nil {
+			t.Fatalf("NewKindling() error = %v", err)
+		}
+		if k == nil {
+			t.Error("NewKindling() = nil; want non-nil")
+		}
+	})
+
+	t.Run("NilFronted_ReturnsError", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewKindling("test", WithDomainFronting(nil))
+		if err == nil {
+			t.Error("NewKindling(WithDomainFronting(nil)) should return error")
+		}
+	})
+
+	t.Run("NilDNSTT_ReturnsError", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewKindling("test", WithDNSTunnel(nil))
+		if err == nil {
+			t.Error("NewKindling(WithDNSTunnel(nil)) should return error")
+		}
+	})
+
+	t.Run("NilAMP_ReturnsError", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewKindling("test", WithAMPCache(nil))
+		if err == nil {
+			t.Error("NewKindling(WithAMPCache(nil)) should return error")
+		}
+	})
+
+	t.Run("NilTransport_ReturnsError", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewKindling("test", WithTransport(nil))
+		if err == nil {
+			t.Error("NewKindling(WithTransport(nil)) should return error")
 		}
 	})
 }
 
 func TestLantern(t *testing.T) {
-	k := NewKindling("kindling",
-		//WithDomainFronting("https://media.githubusercontent.com/media/getlantern/fronted/refs/heads/main/fronted.yaml.gz", ""),
+	k, err := NewKindling("kindling",
 		WithProxyless("config.getiantem.org"),
 	)
+	if err != nil {
+		t.Fatalf("NewKindling() error = %v", err)
+	}
 	client := k.NewHTTPClient()
 	r, err := newRequestWithHeaders(context.Background(), "POST", "https://config.getiantem.org:443/proxies.yaml.gz", http.NoBody)
 	if err != nil {
-		t.Fatalf("newRequestWithHeaders() = %v; want nil", err)
+		t.Fatalf("newRequestWithHeaders() error = %v", err)
 	}
-	fmt.Printf("Request: %v\n", r)
 	res, err := client.Do(r)
 	if err != nil {
-		fmt.Printf("Error: %v\n", err)
-		t.Fatalf("client.Post() = %v; want nil", err)
+		t.Fatalf("client.Do() error = %v", err)
 	}
 	defer res.Body.Close()
-	// Print the response
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		t.Fatalf("io.ReadAll() = %v; want nil", err)
+		t.Fatalf("io.ReadAll() error = %v", err)
 	}
-	fmt.Printf("Response: %s", body)
-
-	// Print the response headers
-	for k, v := range res.Header {
-		fmt.Printf("%s: %s\n", k, v)
-	}
-	//t.Logf("Response: %s", body)
-
+	fmt.Printf("Response: %d bytes, status %d\n", len(body), res.StatusCode)
 }
 
 const (
-	// Required common headers to send to the proxy server.
 	appVersionHeader = "X-Lantern-App-Version"
 	versionHeader    = "X-Lantern-Version"
 	platformHeader   = "X-Lantern-Platform"
@@ -71,27 +98,20 @@ const (
 )
 
 const (
-	AppName = "kindling"
-
-	// Placeholders to use in the request headers.
+	AppName       = "kindling"
 	ClientVersion = "7.6.47"
 	Version       = "7.6.47"
-
-	Platform = "linux"
-	DeviceId = "some-uuid-here"
-
-	// userId and proToken will be set to actual values when user management is implemented.
-	UserId   = "23409" // set to specific value so the server returns a desired config.
-	ProToken = ""
+	Platform      = "linux"
+	DeviceId      = "some-uuid-here"
+	UserId        = "23409"
+	ProToken      = ""
 )
 
-// newRequestWithHeaders creates a new [http.Request] with the required headers.
 func newRequestWithHeaders(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}
-	// add required headers. Currently, all but the auth token are placeholders.
 	req.Header.Set(appVersionHeader, ClientVersion)
 	req.Header.Set(versionHeader, Version)
 	req.Header.Set(userIdHeader, UserId)
@@ -107,120 +127,106 @@ func (d *dummyRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, nil
 }
 
-func TestKindling(t *testing.T) {
+func TestKindling_Suite(t *testing.T) {
 	t.Parallel()
 
 	t.Run("NewKindling", func(t *testing.T) {
 		t.Parallel()
-
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
-
-			kindling := NewKindling("kindling")
-			if kindling == nil {
-				t.Errorf("NewKindling() = nil; want non-nil Kindling")
-			}
-		})
+		k, err := NewKindling("kindling")
+		if err != nil {
+			t.Fatalf("NewKindling() error = %v", err)
+		}
+		if k == nil {
+			t.Error("NewKindling() = nil; want non-nil")
+		}
 	})
 
-	t.Run("kindling.NewHTTPClient", func(t *testing.T) {
+	t.Run("NewHTTPClient", func(t *testing.T) {
 		t.Parallel()
-
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
-
-			kindling := NewKindling("kindling")
-			httpClient := kindling.NewHTTPClient()
-			if httpClient == nil {
-				t.Errorf("kindling.NewHTTPClient() = nil; want non-nil *http.Client")
-			}
-		})
+		k, err := NewKindling("kindling")
+		if err != nil {
+			t.Fatalf("NewKindling() error = %v", err)
+		}
+		client := k.NewHTTPClient()
+		if client == nil {
+			t.Error("NewHTTPClient() = nil; want non-nil")
+		}
 	})
 }
-func TestKindling_ReplaceTransport(t *testing.T) {
+
+func TestReplaceTransport(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Success_ReplaceExistingTransport", func(t *testing.T) {
+	makeTransport := func(name string) Transport {
+		return &namedTransport{
+			name:         name,
+			maxLength:    100,
+			isStreamable: true,
+			newRT: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+				return &dummyRoundTripper{}, nil
+			},
+		}
+	}
+
+	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
-
-		// Create a kindling instance with a transport
-		originalRT := func(ctx context.Context, addr string) (http.RoundTripper, error) {
-			return &dummyRoundTripper{}, nil
+		k, err := NewKindling("test", WithTransport(makeTransport("test-transport")))
+		if err != nil {
+			t.Fatal(err)
 		}
-		transport := newTransport("test-transport", 100, true, originalRT)
-		kindling := NewKindling("test-app", WithTransport(transport))
-
-		// Replace the transport
-		newRT := func(ctx context.Context, addr string) (http.RoundTripper, error) {
+		err = k.ReplaceTransport("test-transport", func(ctx context.Context, addr string) (http.RoundTripper, error) {
 			return &dummyRoundTripper{}, nil
-		}
-		err := kindling.ReplaceTransport("test-transport", newRT)
+		})
 		if err != nil {
 			t.Errorf("ReplaceTransport() error = %v; want nil", err)
 		}
 	})
 
-	t.Run("Error_TransportNotFound", func(t *testing.T) {
+	t.Run("NotFound", func(t *testing.T) {
 		t.Parallel()
-
-		// Create a kindling instance with a transport
-		originalRT := func(ctx context.Context, addr string) (http.RoundTripper, error) {
-			return &dummyRoundTripper{}, nil
+		k, err := NewKindling("test", WithTransport(makeTransport("test-transport")))
+		if err != nil {
+			t.Fatal(err)
 		}
-		transport := newTransport("test-transport", 100, true, originalRT)
-		kindling := NewKindling("test-app", WithTransport(transport))
-
-		// Try to replace a non-existent transport
-		newRT := func(ctx context.Context, addr string) (http.RoundTripper, error) {
+		err = k.ReplaceTransport("nonexistent", func(ctx context.Context, addr string) (http.RoundTripper, error) {
 			return &dummyRoundTripper{}, nil
-		}
-		err := kindling.ReplaceTransport("non-existent-transport", newRT)
+		})
 		if err == nil {
-			t.Errorf("ReplaceTransport() error = nil; want error")
+			t.Error("ReplaceTransport() should fail for unknown transport")
 		}
-		expectedError := "Could not find matching transport: non-existent-transport"
-		if err.Error() != expectedError {
-			t.Errorf("ReplaceTransport() error = %v; want %v", err.Error(), expectedError)
+		if !strings.Contains(err.Error(), "nonexistent") {
+			t.Errorf("error should mention transport name, got: %v", err)
 		}
 	})
 
-	t.Run("Success_ReplaceMultipleTransports", func(t *testing.T) {
+	t.Run("Multiple", func(t *testing.T) {
 		t.Parallel()
-
-		// Create a kindling instance with multiple transports
-		rt1 := func(ctx context.Context, addr string) (http.RoundTripper, error) {
-			return &dummyRoundTripper{}, nil
+		k, err := NewKindling("test",
+			WithTransport(makeTransport("transport-1")),
+			WithTransport(makeTransport("transport-2")),
+		)
+		if err != nil {
+			t.Fatal(err)
 		}
-		rt2 := func(ctx context.Context, addr string) (http.RoundTripper, error) {
+		err = k.ReplaceTransport("transport-2", func(ctx context.Context, addr string) (http.RoundTripper, error) {
 			return &dummyRoundTripper{}, nil
-		}
-		transport1 := newTransport("transport-1", 100, true, rt1)
-		transport2 := newTransport("transport-2", 200, true, rt2)
-		kindling := NewKindling("test-app", WithTransport(transport1), WithTransport(transport2))
-
-		// Replace the second transport
-		newRT := func(ctx context.Context, addr string) (http.RoundTripper, error) {
-			return &dummyRoundTripper{}, nil
-		}
-		err := kindling.ReplaceTransport("transport-2", newRT)
+		})
 		if err != nil {
 			t.Errorf("ReplaceTransport() error = %v; want nil", err)
 		}
 	})
 
-	t.Run("Success_ReplaceEmptyTransportList", func(t *testing.T) {
+	t.Run("EmptyTransportList", func(t *testing.T) {
 		t.Parallel()
-
-		// Create a kindling instance with no transports
-		kindling := NewKindling("test-app")
-
-		// Try to replace a transport
-		newRT := func(ctx context.Context, addr string) (http.RoundTripper, error) {
-			return &dummyRoundTripper{}, nil
+		k, err := NewKindling("test")
+		if err != nil {
+			t.Fatal(err)
 		}
-		err := kindling.ReplaceTransport("any-transport", newRT)
+		err = k.ReplaceTransport("any", func(ctx context.Context, addr string) (http.RoundTripper, error) {
+			return &dummyRoundTripper{}, nil
+		})
 		if err == nil {
-			t.Errorf("ReplaceTransport() error = nil; want error")
+			t.Error("ReplaceTransport() should fail with no transports")
 		}
 	})
 }

--- a/race_transport.go
+++ b/race_transport.go
@@ -110,6 +110,7 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 				"status", resp.StatusCode,
 			)
 			if lastResp != nil {
+				io.Copy(io.Discard, lastResp.Body)
 				lastResp.Body.Close()
 			}
 			lastResp = resp
@@ -185,9 +186,14 @@ func (t *raceTransport) filterTransports(req *http.Request, bodyBytes []byte) []
 }
 
 // hostWithPort ensures the host string includes a port, defaulting based on scheme.
+// Handles bracketed IPv6 literals (e.g. "[::1]") that lack a port.
 func hostWithPort(host, scheme string) string {
 	if _, _, err := net.SplitHostPort(host); err == nil {
 		return host
+	}
+	// Strip brackets from IPv6 literals so JoinHostPort doesn't double-bracket.
+	if len(host) > 1 && host[0] == '[' && host[len(host)-1] == ']' {
+		host = host[1 : len(host)-1]
 	}
 	if scheme == "https" {
 		return net.JoinHostPort(host, "443")
@@ -211,7 +217,7 @@ func cloneRequest(req *http.Request, app, method string, bodyBytes []byte) *http
 // requestTimeout returns the appropriate timeout for the request — longer
 // for uploads with content, shorter for GETs and small requests.
 func requestTimeout(req *http.Request) time.Duration {
-	if req.ContentLength > 0 {
+	if req.Body != nil && req.Body != http.NoBody && req.ContentLength != 0 {
 		return 3 * time.Minute
 	}
 	return 80 * time.Second

--- a/race_transport.go
+++ b/race_transport.go
@@ -9,194 +9,224 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"sync"
-	"sync/atomic"
 	"time"
 )
 
+// raceTransport is an http.RoundTripper that races requests across multiple
+// transports. Connections are established concurrently, but requests are sent
+// serially in the order transports connect — avoiding issues with
+// non-idempotent requests.
 type raceTransport struct {
 	transports    []Transport
 	panicListener func(string)
 	appName       string
+	log           *slog.Logger
 }
 
-func newRaceTransport(appName string, panicListener func(string), transports ...Transport) http.RoundTripper {
-	if panicListener == nil {
-		panicListener = func(msg string) {
-			log.Error(msg)
-		}
-	}
+func newRaceTransport(appName string, log *slog.Logger, panicListener func(string), transports []Transport) *raceTransport {
 	return &raceTransport{
 		transports:    transports,
 		panicListener: panicListener,
 		appName:       appName,
+		log:           log,
 	}
 }
 
-type namedRoundTripper struct {
-	http.RoundTripper
+// connectResult holds the outcome of a single transport connection attempt.
+type connectResult struct {
+	rt   http.RoundTripper
 	name string
+	err  error
 }
 
-func (t *raceTransport) RoundTrip(originalRequest *http.Request) (*http.Response, error) {
-	// Try all methods in parallel and return the first successful response.
-	// If all fail, return the last error.
-	ctx, cancel := context.WithTimeout(originalRequest.Context(), timeout(originalRequest))
-
-	// Note that this will cancel the context when the first response is received,
-	// canceling any other in-flight requests that respect the context (which they should).
+func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx, cancel := context.WithTimeout(req.Context(), requestTimeout(req))
 	defer cancel()
-	var httpErrors = new(atomic.Int64)
-	var rtChan = make(chan *namedRoundTripper, len(t.transports))
-	var errCh = make(chan error, len(t.transports))
-	errFunc := func(err error) {
-		if httpErrors.Add(1) == int64(len(t.transports)) {
-			errCh <- fmt.Errorf("failed to connect to any dialer with last error: %v", err)
-		}
-	}
-	// Store a raw copy of the request body for request copies sent to the various
-	// transports.
-	bodyBytes := requestBodyBytes(originalRequest)
-	hasStreamingHeader := originalRequest.Header.Get("accept") == "text/event-stream"
-	log.Debug(fmt.Sprintf("Dialing with %v dialers and body length %v", len(t.transports), len(bodyBytes)))
-	for _, tr := range t.transports {
-		hasLimit := tr.MaxLength() > 0
-		if hasLimit && len(bodyBytes) > tr.MaxLength() {
-			log.Debug("Skipping transport due to size limit", "name", tr.Name(), "size", len(bodyBytes), "maxLength", tr.MaxLength())
-			continue
-		}
-		if hasStreamingHeader && !tr.IsStreamable() {
-			log.Debug("Skipping transport because it doesn't support streaming", slog.String("name", tr.Name()))
-			continue
-		}
-		go func(tr Transport) {
-			// Recover from panics in the dialer.
-			defer func() {
-				if r := recover(); r != nil {
-					t.panicListener(fmt.Sprintf("panic in dialer: %v", r))
-					errCh <- fmt.Errorf("panic in dialer: %v", r)
-				}
-			}()
-			t.connectedRoundTripper(ctx, tr, originalRequest, errFunc, rtChan)
-		}(tr)
+
+	bodyBytes, err := drainRequestBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("reading request body: %w", err)
 	}
 
-	// Select up to the first response or error, or until we've hit the target number of tries or the context is canceled.
-	retryTimes := len(t.transports)
-	var lastResponse *http.Response
-	for range retryTimes {
+	eligible := t.filterTransports(req, bodyBytes)
+	if len(eligible) == 0 {
+		return nil, errors.New("no eligible transports for request")
+	}
+
+	t.log.Debug("Racing transports",
+		"count", len(eligible),
+		"bodyLength", len(bodyBytes),
+	)
+
+	// Connect all eligible transports in parallel. Each goroutine sends
+	// exactly one result, so the channel will receive len(eligible) messages.
+	results := make(chan connectResult, len(eligible))
+	addr := hostWithPort(req.URL.Host, req.URL.Scheme)
+	for _, tr := range eligible {
+		go t.connect(ctx, tr, addr, results)
+	}
+
+	// Try connected transports as they arrive. Because we consume results
+	// one at a time, requests are sent serially.
+	var lastResp *http.Response
+	var lastErr error
+
+	for remaining := len(eligible); remaining > 0; remaining-- {
 		select {
-		case rt := <-rtChan:
-			// If we get a connection, try to send the request.
-			log.Debug("Got connected RoundTripper", "name", rt.name)
-
-			// Create a request with a cloned body to avoid issues with concurrent reads corrupting the body.
-			req := cloneRequest(originalRequest, t.appName, rt.name, bodyBytes)
-			resp, err := rt.RoundTrip(req)
-			if err != nil {
-				log.Error("HTTP request failed", "name", rt.name, "err", err)
-				errFunc(err)
+		case result := <-results:
+			if result.err != nil {
+				t.log.Error("Transport connection failed",
+					"name", result.name,
+					"error", result.err,
+				)
+				lastErr = result.err
 				continue
 			}
-			// Treat all 2xx and 3xx responses as successful.
+
+			t.log.Debug("Transport connected", "name", result.name)
+			clone := cloneRequest(req, t.appName, result.name, bodyBytes)
+			resp, err := result.rt.RoundTrip(clone)
+			if err != nil {
+				t.log.Error("HTTP request failed",
+					"name", result.name,
+					"error", err,
+				)
+				lastErr = err
+				continue
+			}
+
 			if resp.StatusCode < http.StatusBadRequest {
-				log.Debug("HTTP request succeeded", "name", rt.name, "status", resp.StatusCode)
+				t.log.Debug("Request succeeded",
+					"name", result.name,
+					"status", resp.StatusCode,
+				)
 				return resp, nil
 			}
-			// Given how many weird transports we're using underneath (i.e., it may be the intermediary transport
-			// returning the response, not actually the destination server) we treat all other responses as retryable.
-			log.Error("HTTP request returned retryable status", "name", rt.name, "status", resp.StatusCode)
-			lastResponse = resp
-			errFunc(fmt.Errorf("http status %d", resp.StatusCode))
-		case err := <-errCh:
-			log.Error("RoundTrip error", "error", err)
-			return nil, err
+
+			// Retryable status — close previous failed response, keep this one
+			// in case no transport succeeds.
+			t.log.Warn("Retryable HTTP status",
+				"name", result.name,
+				"status", resp.StatusCode,
+			)
+			if lastResp != nil {
+				lastResp.Body.Close()
+			}
+			lastResp = resp
+			lastErr = fmt.Errorf("transport %s: http status %d", result.name, resp.StatusCode)
+
 		case <-ctx.Done():
+			if lastResp != nil {
+				return lastResp, nil
+			}
+			if lastErr != nil {
+				return nil, fmt.Errorf("timed out, last error: %w", lastErr)
+			}
 			return nil, ctx.Err()
 		}
 	}
-	if lastResponse != nil {
-		return lastResponse, nil
+
+	// All transports exhausted.
+	if lastResp != nil {
+		return lastResp, nil
 	}
-	return nil, errors.New("failed to get response")
+	if lastErr != nil {
+		return nil, fmt.Errorf("all transports failed: %w", lastErr)
+	}
+	return nil, errors.New("no transports produced a response")
 }
 
-func (t *raceTransport) connectedRoundTripper(ctx context.Context, tr Transport, originalReq *http.Request, errFunc func(error), rtChan chan *namedRoundTripper) {
-	// We first create connected http.RoundTrippers prior to sending the request.
-	// With this method, we don't have to worry about the idempotency of the request
-	// because we ultimately try the connections serially in the next step.
-	addr := originalReq.URL.Host
-
-	// The smart dialer requires the port to be specified, so we add it if it's
-	// missing. We can't do this in the dialer itself because the scheme
-	// is stripped by the time the dialer is called.
-	if _, _, err := net.SplitHostPort(addr); err != nil {
-		if originalReq.URL.Scheme == "https" {
-			addr = net.JoinHostPort(addr, "443")
-		} else {
-			addr = net.JoinHostPort(addr, "80")
+// connect establishes a connection using the given transport and sends the
+// result (success or failure) on the results channel. Panics are recovered.
+func (t *raceTransport) connect(ctx context.Context, tr Transport, addr string, results chan<- connectResult) {
+	defer func() {
+		if r := recover(); r != nil {
+			msg := fmt.Sprintf("panic in transport %s: %v", tr.Name(), r)
+			t.panicListener(msg)
+			results <- connectResult{name: tr.Name(), err: errors.New(msg)}
 		}
-	}
+	}()
 
-	connectedRoundTripper, err := tr.NewRoundTripper(ctx, addr)
+	rt, err := tr.NewRoundTripper(ctx, addr)
 	if err != nil {
-		errFunc(err)
-	} else {
-		if ctx.Err() != nil {
-			// context is canceled - we should not proceed with the request
-			log.Debug("Context canceled before sending request", "host", originalReq.URL.Host)
-			errFunc(ctx.Err())
-			return
+		results <- connectResult{name: tr.Name(), err: err}
+		return
+	}
+	if ctx.Err() != nil {
+		results <- connectResult{name: tr.Name(), err: ctx.Err()}
+		return
+	}
+	results <- connectResult{rt: rt, name: tr.Name()}
+}
+
+// filterTransports returns only the transports eligible for this request,
+// based on body size limits and streaming support.
+func (t *raceTransport) filterTransports(req *http.Request, bodyBytes []byte) []Transport {
+	isStreaming := req.Header.Get("Accept") == "text/event-stream"
+	eligible := make([]Transport, 0, len(t.transports))
+	for _, tr := range t.transports {
+		if tr.MaxLength() > 0 && len(bodyBytes) > tr.MaxLength() {
+			t.log.Debug("Skipping transport: body exceeds limit",
+				"name", tr.Name(),
+				"bodySize", len(bodyBytes),
+				"maxLength", tr.MaxLength(),
+			)
+			continue
 		}
-		rtChan <- &namedRoundTripper{RoundTripper: connectedRoundTripper, name: tr.Name()}
+		if isStreaming && !tr.IsStreamable() {
+			t.log.Debug("Skipping non-streamable transport",
+				"name", tr.Name(),
+			)
+			continue
+		}
+		eligible = append(eligible, tr)
 	}
+	return eligible
 }
 
-// Protect the http request with a mutex to avoid concurrent reads.
-var reqMutex = new(sync.Mutex)
+// hostWithPort ensures the host string includes a port, defaulting based on scheme.
+func hostWithPort(host, scheme string) string {
+	if _, _, err := net.SplitHostPort(host); err == nil {
+		return host
+	}
+	if scheme == "https" {
+		return net.JoinHostPort(host, "443")
+	}
+	return net.JoinHostPort(host, "80")
+}
 
-// cloneRequest creates a copy of the provided HTTP request, including its body.
-// If the body is nil or http.NoBody, it simply returns a clone without reading the body.
-// This is important because, since we're racing requests, it's possible that the body
-// has been consumed by a previous request.
+// cloneRequest creates a copy of the HTTP request with the body replaced by
+// bodyBytes and Kindling-specific tracing headers added.
 func cloneRequest(req *http.Request, app, method string, bodyBytes []byte) *http.Request {
-	reqMutex.Lock()
-	defer reqMutex.Unlock()
-	clonedReq := req.Clone(req.Context())
-	clonedReq.Header.Add("X-Kindling-App", app)
-	clonedReq.Header.Add("X-Kindling-Method", method)
-	if req.Body == http.NoBody || req.Body == nil {
-		// If the request body is nil, we can just return a clone without reading it.
-		return clonedReq
+	clone := req.Clone(req.Context())
+	clone.Header.Set("X-Kindling-App", app)
+	clone.Header.Set("X-Kindling-Method", method)
+	if req.Body != nil && req.Body != http.NoBody && len(bodyBytes) > 0 {
+		clone.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		clone.ContentLength = int64(len(bodyBytes))
 	}
-	clonedReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-	return clonedReq
+	return clone
 }
 
-func timeout(req *http.Request) time.Duration {
-	cl := req.Header.Get("Content-Length")
-
-	// If there is no content length or it's zero, give a reduced timeout,
-	// but not too short given that some transports can take awhile to
-	// get set up.
-	if cl == "" || cl == "0" {
-		return 80 * time.Second
+// requestTimeout returns the appropriate timeout for the request — longer
+// for uploads with content, shorter for GETs and small requests.
+func requestTimeout(req *http.Request) time.Duration {
+	if req.ContentLength > 0 {
+		return 3 * time.Minute
 	}
-
-	// For larger uploads, give more time.
-	return 3 * time.Minute
+	return 80 * time.Second
 }
 
-func requestBodyBytes(req *http.Request) []byte {
+// drainRequestBody reads the full request body into a byte slice and restores
+// it on the request. Returns nil for requests with no body.
+func drainRequestBody(req *http.Request) ([]byte, error) {
 	if req.Body == nil || req.Body == http.NoBody {
-		return []byte{}
+		return nil, nil
 	}
 	bodyBytes, err := io.ReadAll(req.Body)
 	if err != nil {
-		log.Error("Error reading request body:", "error", err)
-		return []byte{}
+		return nil, err
 	}
-	// Restore the original request body for future reads.
 	req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-	return bodyBytes
+	return bodyBytes, nil
 }

--- a/race_transport_test.go
+++ b/race_transport_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -14,6 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var testLog = slog.New(slog.NewTextHandler(os.Stderr, nil))
 
 // mockTransport is a test implementation of Transport that records whether it was called.
 type mockTransport struct {
@@ -33,8 +37,6 @@ func (m *mockTransport) NewRoundTripper(ctx context.Context, addr string) (http.
 func TestRaceTransport_StreamingHeaderFilter(t *testing.T) {
 	t.Parallel()
 
-	// Verifies that when the Accept header is "text/event-stream", only streamable
-	// transports are used and non-streamable ones are skipped entirely.
 	t.Run("StreamingRequest_SkipsNonStreamableTransport", func(t *testing.T) {
 		t.Parallel()
 
@@ -44,21 +46,23 @@ func TestRaceTransport_StreamingHeaderFilter(t *testing.T) {
 		defer server.Close()
 
 		var streamableCalled, nonStreamableCalled atomic.Bool
-		rt := newRaceTransport("test", func(string) {},
-			&mockTransport{
-				name:         "streamable",
-				isStreamable: true,
-				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
-					streamableCalled.Store(true)
-					return server.Client().Transport, nil
+		rt := newRaceTransport("test", testLog, func(string) {},
+			[]Transport{
+				&mockTransport{
+					name:         "streamable",
+					isStreamable: true,
+					newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+						streamableCalled.Store(true)
+						return server.Client().Transport, nil
+					},
 				},
-			},
-			&mockTransport{
-				name:         "non-streamable",
-				isStreamable: false,
-				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
-					nonStreamableCalled.Store(true)
-					return server.Client().Transport, nil
+				&mockTransport{
+					name:         "non-streamable",
+					isStreamable: false,
+					newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+						nonStreamableCalled.Store(true)
+						return server.Client().Transport, nil
+					},
 				},
 			},
 		)
@@ -75,8 +79,6 @@ func TestRaceTransport_StreamingHeaderFilter(t *testing.T) {
 		assert.False(t, nonStreamableCalled.Load(), "non-streamable transport should be skipped for streaming request")
 	})
 
-	// Verifies that a streamable transport successfully handles a streaming
-	// request end-to-end and returns a successful response.
 	t.Run("StreamingRequest_UsesStreamableTransport", func(t *testing.T) {
 		t.Parallel()
 
@@ -86,13 +88,15 @@ func TestRaceTransport_StreamingHeaderFilter(t *testing.T) {
 		defer server.Close()
 
 		var called atomic.Bool
-		rt := newRaceTransport("test", func(string) {},
-			&mockTransport{
-				name:         "streamable",
-				isStreamable: true,
-				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
-					called.Store(true)
-					return server.Client().Transport, nil
+		rt := newRaceTransport("test", testLog, func(string) {},
+			[]Transport{
+				&mockTransport{
+					name:         "streamable",
+					isStreamable: true,
+					newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+						called.Store(true)
+						return server.Client().Transport, nil
+					},
 				},
 			},
 		)
@@ -108,34 +112,33 @@ func TestRaceTransport_StreamingHeaderFilter(t *testing.T) {
 		assert.True(t, called.Load(), "streamable transport should be called for streaming request")
 	})
 
-	// Verifies that the streaming filter is not applied for ordinary (non-streaming)
-	// requests, so both streamable and non-streamable transports are attempted.
 	t.Run("NonStreamingRequest_AllowsNonStreamableTransport", func(t *testing.T) {
 		t.Parallel()
 
 		var streamableCalled, nonStreamableCalled atomic.Bool
-		rt := newRaceTransport("test", func(string) {},
-			&mockTransport{
-				name:         "streamable",
-				isStreamable: true,
-				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
-					streamableCalled.Store(true)
-					return nil, errors.New("intentional error")
+		rt := newRaceTransport("test", testLog, func(string) {},
+			[]Transport{
+				&mockTransport{
+					name:         "streamable",
+					isStreamable: true,
+					newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+						streamableCalled.Store(true)
+						return nil, errors.New("intentional error")
+					},
 				},
-			},
-			&mockTransport{
-				name:         "non-streamable",
-				isStreamable: false,
-				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
-					nonStreamableCalled.Store(true)
-					return nil, errors.New("intentional error")
+				&mockTransport{
+					name:         "non-streamable",
+					isStreamable: false,
+					newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+						nonStreamableCalled.Store(true)
+						return nil, errors.New("intentional error")
+					},
 				},
 			},
 		)
 
 		req, err := http.NewRequest("GET", "http://example.com", nil)
 		require.NoError(t, err)
-		// No Accept: text/event-stream header — streaming filter must not apply.
 
 		_, err = rt.RoundTrip(req)
 		require.Error(t, err, "expected error when all transports fail")
@@ -145,59 +148,233 @@ func TestRaceTransport_StreamingHeaderFilter(t *testing.T) {
 	})
 }
 
+func TestRaceTransport_NoEligibleTransports(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AllFilteredBySize", func(t *testing.T) {
+		t.Parallel()
+
+		rt := newRaceTransport("test", testLog, func(string) {},
+			[]Transport{
+				&mockTransport{
+					name:      "limited",
+					maxLength: 10,
+					newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+						t.Error("should not be called")
+						return nil, nil
+					},
+				},
+			},
+		)
+
+		largeBody := strings.Repeat("x", 100)
+		req, err := http.NewRequest("POST", "http://example.com", strings.NewReader(largeBody))
+		require.NoError(t, err)
+
+		_, err = rt.RoundTrip(req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no eligible transports")
+	})
+
+	t.Run("EmptyTransportList", func(t *testing.T) {
+		t.Parallel()
+
+		rt := newRaceTransport("test", testLog, func(string) {}, nil)
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+
+		_, err = rt.RoundTrip(req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no eligible transports")
+	})
+}
+
+func TestRaceTransport_AllTransportsFail(t *testing.T) {
+	t.Parallel()
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			&mockTransport{
+				name: "fail-1",
+				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+					return nil, errors.New("connect error 1")
+				},
+			},
+			&mockTransport{
+				name: "fail-2",
+				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+					return nil, errors.New("connect error 2")
+				},
+			},
+		},
+	)
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all transports failed")
+}
+
+func TestRaceTransport_FirstSuccessWins(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	var slowCalled atomic.Bool
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			&mockTransport{
+				name: "fast",
+				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+					return server.Client().Transport, nil
+				},
+			},
+			&mockTransport{
+				name: "slow",
+				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+					<-ctx.Done()
+					slowCalled.Store(true)
+					return nil, ctx.Err()
+				},
+			},
+		},
+	)
+
+	req, err := http.NewRequest("GET", server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRaceTransport_PanicRecovery(t *testing.T) {
+	t.Parallel()
+
+	var panicMsg string
+	rt := newRaceTransport("test", testLog, func(msg string) { panicMsg = msg },
+		[]Transport{
+			&mockTransport{
+				name: "panicker",
+				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+					panic("boom")
+				},
+			},
+		},
+	)
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.Error(t, err)
+	assert.Contains(t, panicMsg, "boom")
+}
+
 func TestCloneRequest_NilBody(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://example.com", nil)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
-	cloned := cloneRequest(req, "test", "test", []byte{})
-	if cloned == req {
-		t.Error("expected a new request, got the same pointer")
-	}
-	if cloned.Body != nil && cloned.Body != http.NoBody {
-		t.Error("expected cloned body to be nil or http.NoBody")
-	}
+	require.NoError(t, err)
+
+	cloned := cloneRequest(req, "test", "test", nil)
+	assert.NotSame(t, req, cloned)
+	assert.True(t, cloned.Body == nil || cloned.Body == http.NoBody,
+		"expected nil or NoBody, got %v", cloned.Body)
 }
 
 func TestCloneRequest_NoBody(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://example.com", http.NoBody)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
-	cloned := cloneRequest(req, "test", "test", []byte{})
-	if cloned == req {
-		t.Error("expected a new request, got the same pointer")
-	}
-	if cloned.Body != http.NoBody {
-		t.Error("expected cloned body to be http.NoBody")
-	}
+	require.NoError(t, err)
+
+	cloned := cloneRequest(req, "test", "test", nil)
+	assert.NotSame(t, req, cloned)
+	assert.Equal(t, http.NoBody, cloned.Body)
 }
 
 func TestCloneRequest_WithBody(t *testing.T) {
 	originalBody := "hello world"
 	req, err := http.NewRequest("POST", "http://example.com", io.NopCloser(strings.NewReader(originalBody)))
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
-	bodyBytes, _ := io.ReadAll(req.Body)
+	require.NoError(t, err)
 
-	cloned := cloneRequest(req, "test", "test", bodyBytes)
+	bodyBytes, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
 
-	// Both bodies should be readable and equal to originalBody
-	req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-	origBodyBytes, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatalf("failed to read original body: %v", err)
-	}
-	if string(origBodyBytes) != originalBody {
-		t.Errorf("expected original body %q, got %q", originalBody, string(origBodyBytes))
-	}
+	cloned := cloneRequest(req, "test", "method-x", bodyBytes)
 
-	clonedBodyBytes, err := io.ReadAll(cloned.Body)
-	if err != nil {
-		t.Fatalf("failed to read cloned body: %v", err)
+	// Verify cloned body matches original content.
+	clonedBody, err := io.ReadAll(cloned.Body)
+	require.NoError(t, err)
+	assert.Equal(t, originalBody, string(clonedBody))
+
+	// Verify Kindling headers are set.
+	assert.Equal(t, "test", cloned.Header.Get("X-Kindling-App"))
+	assert.Equal(t, "method-x", cloned.Header.Get("X-Kindling-Method"))
+
+	// Verify ContentLength is set correctly.
+	assert.Equal(t, int64(len(originalBody)), cloned.ContentLength)
+}
+
+func TestHostWithPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		host, scheme, want string
+	}{
+		{"example.com", "https", "example.com:443"},
+		{"example.com", "http", "example.com:80"},
+		{"example.com:8080", "https", "example.com:8080"},
+		{"example.com:8080", "http", "example.com:8080"},
 	}
-	if string(clonedBodyBytes) != originalBody {
-		t.Errorf("expected cloned body %q, got %q", originalBody, string(clonedBodyBytes))
+	for _, tt := range tests {
+		got := hostWithPort(tt.host, tt.scheme)
+		assert.Equal(t, tt.want, got, "hostWithPort(%q, %q)", tt.host, tt.scheme)
 	}
+}
+
+func TestDrainRequestBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NilBody", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		body, err := drainRequestBody(req)
+		require.NoError(t, err)
+		assert.Nil(t, body)
+	})
+
+	t.Run("WithContent", func(t *testing.T) {
+		content := "request body"
+		req, _ := http.NewRequest("POST", "http://example.com", strings.NewReader(content))
+		body, err := drainRequestBody(req)
+		require.NoError(t, err)
+		assert.Equal(t, content, string(body))
+
+		// Verify body was restored on the request.
+		restored, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		assert.Equal(t, content, string(restored))
+	})
+}
+
+func TestRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoContent", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		assert.Equal(t, 80*1_000_000_000, int(requestTimeout(req)))
+	})
+
+	t.Run("WithContent", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "http://example.com",
+			bytes.NewReader(make([]byte, 1000)))
+		req.ContentLength = 1000
+		assert.Equal(t, 180*1_000_000_000, int(requestTimeout(req)))
+	})
 }

--- a/race_transport_test.go
+++ b/race_transport_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -332,6 +333,9 @@ func TestHostWithPort(t *testing.T) {
 		{"example.com", "http", "example.com:80"},
 		{"example.com:8080", "https", "example.com:8080"},
 		{"example.com:8080", "http", "example.com:8080"},
+		{"[::1]", "https", "[::1]:443"},
+		{"[::1]", "http", "[::1]:80"},
+		{"[::1]:8080", "https", "[::1]:8080"},
 	}
 	for _, tt := range tests {
 		got := hostWithPort(tt.host, tt.scheme)
@@ -343,7 +347,8 @@ func TestDrainRequestBody(t *testing.T) {
 	t.Parallel()
 
 	t.Run("NilBody", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
 		body, err := drainRequestBody(req)
 		require.NoError(t, err)
 		assert.Nil(t, body)
@@ -351,7 +356,8 @@ func TestDrainRequestBody(t *testing.T) {
 
 	t.Run("WithContent", func(t *testing.T) {
 		content := "request body"
-		req, _ := http.NewRequest("POST", "http://example.com", strings.NewReader(content))
+		req, err := http.NewRequest("POST", "http://example.com", strings.NewReader(content))
+		require.NoError(t, err)
 		body, err := drainRequestBody(req)
 		require.NoError(t, err)
 		assert.Equal(t, content, string(body))
@@ -367,14 +373,16 @@ func TestRequestTimeout(t *testing.T) {
 	t.Parallel()
 
 	t.Run("NoContent", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "http://example.com", nil)
-		assert.Equal(t, 80*1_000_000_000, int(requestTimeout(req)))
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		assert.Equal(t, 80*time.Second, requestTimeout(req))
 	})
 
 	t.Run("WithContent", func(t *testing.T) {
-		req, _ := http.NewRequest("POST", "http://example.com",
+		req, err := http.NewRequest("POST", "http://example.com",
 			bytes.NewReader(make([]byte, 1000)))
+		require.NoError(t, err)
 		req.ContentLength = 1000
-		assert.Equal(t, 180*1_000_000_000, int(requestTimeout(req)))
+		assert.Equal(t, 3*time.Minute, requestTimeout(req))
 	})
 }


### PR DESCRIPTION
## Summary
- **Fixed deadlock bug** in race transport where filtered transports caused the error counter to never reach its threshold, blocking until the 80-second timeout
- **Fixed double-counting** where connection-phase and request-phase errors were mixed in the same atomic counter, potentially triggering premature "all failed" errors
- **Fixed response body leak** — retryable 4xx+ responses were never closed before moving to the next transport
- **Eliminated global mutable state** — replaced package-level `var log` (data race across instances) and `var reqMutex` (unnecessary cross-instance serialization) with per-instance logger
- **Simplified option system** — `Option` is now `func(*kindling) error` instead of interface+priority+sort; `NewKindling` returns errors instead of silently swallowing them
- **Thread-safe `NewHTTPClient`** — snapshots transport slice under mutex so concurrent `ReplaceTransport` calls don't race
- **Expanded test coverage** — added tests for panic recovery, no eligible transports, all transports failing, first-success-wins race, hostWithPort, drainRequestBody, requestTimeout

### Race transport redesign
The core fix replaces the split `rtChan`/`errCh` + `atomic.Int64` pattern with a single `results` channel where every goroutine sends exactly one `connectResult` (success or failure). The main loop counts down from `len(eligible)` instead of `len(t.transports)`, so it always terminates correctly.

## Test plan
- [x] All 22 unit tests pass (`go test -v`)
- [x] `go vet` clean
- [x] `go build` clean
- [ ] Manual integration test with `TestLantern` against live config endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)