### PR TITLE
race transport: method-aware retry preserves non-idempotent safety

### DIFF
--- a/race_transport.go
+++ b/race_transport.go
@@ -12,10 +12,35 @@ import (
 	"time"
 )
 
-// raceTransport is an http.RoundTripper that races requests across multiple
-// transports. Connections are established concurrently, but requests are sent
-// serially in the order transports connect — avoiding issues with
-// non-idempotent requests.
+// raceTransport is an http.RoundTripper that races *connections* across
+// multiple transports. Connections are established concurrently; the first
+// transport to connect receives the request, and the response is returned
+// to the caller.
+//
+// Retry behavior is method-aware:
+//
+//   - For idempotent methods (GET, HEAD), the original retry-across-transports
+//     behavior is preserved: transport-level errors after RoundTrip and 5xx
+//     responses fall back to the next connected transport. This handles the
+//     case where an intermediary fronting transport (rather than the origin)
+//     produced the 5xx — common when one fronting CDN is being blocked.
+//     4xx responses are NOT retried even for idempotent methods: a 4xx is
+//     the server's verdict on the request itself, so retrying won't help.
+//
+//   - For non-idempotent methods (POST/PUT/DELETE/PATCH/etc.), exactly one
+//     request is sent once any transport connects, and the response is
+//     returned regardless of status or transport error. Retrying would
+//     risk replaying server-side side effects (DB writes, registrations,
+//     billing events) — once the body has crossed the wire, the server
+//     may have processed it even if the response was lost in transit.
+//     PUT/DELETE are technically idempotent per RFC 7231 but are excluded
+//     here because the side effect may have been applied before a transient
+//     failure dropped the response, matching stdlib http.Client's stricter
+//     view of which methods are safe to replay.
+//
+// Connections that fail to establish always fall back to the next transport
+// regardless of method — no body has been transmitted on a connection that
+// never came up, so replay risk is zero.
 type raceTransport struct {
 	transports    []Transport
 	panicListener func(string)
@@ -66,8 +91,7 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		go t.connect(ctx, tr, addr, results)
 	}
 
-	// Try connected transports as they arrive. Because we consume results
-	// one at a time, requests are sent serially.
+	idempotent := isRetryableMethod(req.Method)
 	var lastResp *http.Response
 	var lastErr error
 
@@ -83,38 +107,51 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 				continue
 			}
 
-			t.log.Debug("Transport connected", "name", result.name)
+			t.log.Debug("Transport connected, sending request", "name", result.name, "method", req.Method)
 			clone := cloneRequest(req, t.appName, result.name, bodyBytes)
 			resp, err := result.rt.RoundTrip(clone)
+
+			if !idempotent {
+				// Single-shot: return whatever happened. Retrying on a non-
+				// idempotent method risks replaying side effects.
+				return resp, err
+			}
+
 			if err != nil {
-				t.log.Error("HTTP request failed",
+				t.log.Warn("HTTP request failed on idempotent method, falling back",
 					"name", result.name,
+					"method", req.Method,
 					"error", err,
 				)
 				lastErr = err
 				continue
 			}
 
-			if resp.StatusCode < http.StatusBadRequest {
-				t.log.Debug("Request succeeded",
+			if resp.StatusCode >= 500 {
+				// 5xx on an idempotent method — the response may be from a
+				// blocked intermediary rather than the origin. Try the next
+				// transport. Hold this response in case nothing else works.
+				t.log.Warn("Retryable 5xx on idempotent method, falling back",
 					"name", result.name,
+					"method", req.Method,
 					"status", resp.StatusCode,
 				)
-				return resp, nil
+				if lastResp != nil {
+					_, _ = io.Copy(io.Discard, lastResp.Body)
+					_ = lastResp.Body.Close()
+				}
+				lastResp = resp
+				lastErr = fmt.Errorf("transport %s: http status %d", result.name, resp.StatusCode)
+				continue
 			}
 
-			// Retryable status — close previous failed response, keep this one
-			// in case no transport succeeds.
-			t.log.Warn("Retryable HTTP status",
-				"name", result.name,
-				"status", resp.StatusCode,
-			)
+			// 2xx, 3xx, or 4xx on an idempotent method: 4xx is the server's
+			// verdict on the request itself, retry won't help. Return.
 			if lastResp != nil {
-				io.Copy(io.Discard, lastResp.Body)
-				lastResp.Body.Close()
+				_, _ = io.Copy(io.Discard, lastResp.Body)
+				_ = lastResp.Body.Close()
 			}
-			lastResp = resp
-			lastErr = fmt.Errorf("transport %s: http status %d", result.name, resp.StatusCode)
+			return resp, nil
 
 		case <-ctx.Done():
 			if lastResp != nil {
@@ -135,6 +172,22 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("all transports failed: %w", lastErr)
 	}
 	return nil, errors.New("no transports produced a response")
+}
+
+// isRetryableMethod reports whether requests with this method are safe to
+// replay on a different transport after a transport-level error or 5xx
+// response. Only GET and HEAD are included: they have no side effects
+// (RFC 7231 §4.2.1 "safe" methods) and the stdlib http.Client uses the
+// same conservative position. PUT/DELETE are technically idempotent per
+// the RFC but a server may have applied the side effect before a transient
+// failure dropped the response, so replaying them is unsafe.
+func isRetryableMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, "":
+		// Empty method defaults to GET in net/http.
+		return true
+	}
+	return false
 }
 
 // connect establishes a connection using the given transport and sends the

--- a/race_transport.go
+++ b/race_transport.go
@@ -123,6 +123,14 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 					"method", req.Method,
 					"error", err,
 				)
+				// http.RoundTripper allows resp to be non-nil even when
+				// err is non-nil (the spec only requires resp == nil when
+				// err == nil for the success direction). Drain + close
+				// defensively so we don't leak the body / connection.
+				if resp != nil {
+					_, _ = io.Copy(io.Discard, resp.Body)
+					_ = resp.Body.Close()
+				}
 				lastErr = err
 				continue
 			}

--- a/race_transport_test.go
+++ b/race_transport_test.go
@@ -281,6 +281,301 @@ func TestRaceTransport_PanicRecovery(t *testing.T) {
 	assert.Contains(t, panicMsg, "boom")
 }
 
+// 4xx is the server's verdict on the request — replaying the request body
+// on another transport would mean a non-idempotent handler ran twice. Pin
+// the contract: 4xx returns to the caller, no second transport gets hit.
+func TestRaceTransport_FourXX_NotRetried(t *testing.T) {
+	t.Parallel()
+
+	var firstHits, secondHits atomic.Int64
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		firstHits.Add(1)
+		http.Error(w, "verify failed", http.StatusUnprocessableEntity)
+	}))
+	defer first.Close()
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		secondHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer second.Close()
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			redirectTransport("first", first.URL),
+			// Delay the second transport's connection so the first wins
+			// the race deterministically.
+			delayedTransport("second", second.URL, 50*time.Millisecond),
+		},
+	)
+
+	req, err := http.NewRequest("POST", "http://example.com/peer/verify", strings.NewReader(`{}`))
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+		"4xx response from the first transport must be returned to the caller")
+	assert.Equal(t, int64(1), firstHits.Load(), "first transport must see exactly one request")
+	// Wait briefly for the second transport's connect goroutine to settle —
+	// we want to prove RoundTrip wasn't called on it even after it connects.
+	time.Sleep(150 * time.Millisecond)
+	assert.Equal(t, int64(0), secondHits.Load(),
+		"second transport must NOT receive the request — replaying a non-idempotent body is the bug we're guarding against")
+}
+
+// 5xx is also the server's verdict (or an upstream proxy's) — same
+// reasoning as 4xx. Document the contract for both.
+func TestRaceTransport_FiveXX_NotRetried(t *testing.T) {
+	t.Parallel()
+
+	var firstHits, secondHits atomic.Int64
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		firstHits.Add(1)
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer first.Close()
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		secondHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer second.Close()
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			redirectTransport("first", first.URL),
+			delayedTransport("second", second.URL, 50*time.Millisecond),
+		},
+	)
+
+	req, err := http.NewRequest("POST", "http://example.com/peer/verify", strings.NewReader(`{}`))
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, int64(1), firstHits.Load())
+	time.Sleep(150 * time.Millisecond)
+	assert.Equal(t, int64(0), secondHits.Load())
+}
+
+// Idempotent-method exception: 5xx on a GET is allowed to fall back to
+// the next transport. Real-world driver: a domain-front returning 5xx
+// because it's being blocked, while the origin would happily respond.
+// GET is safe to replay; the server has no side effects to replay.
+func TestRaceTransport_FiveXX_RetriedForGET(t *testing.T) {
+	t.Parallel()
+
+	var firstHits, secondHits atomic.Int64
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		firstHits.Add(1)
+		http.Error(w, "blocked", http.StatusBadGateway)
+	}))
+	defer first.Close()
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		secondHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer second.Close()
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			redirectTransport("first", first.URL),
+			delayedTransport("second", second.URL, 50*time.Millisecond),
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/config-new", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"GET must fall back from 502 (first) to 200 (second)")
+	assert.Equal(t, int64(1), firstHits.Load())
+	assert.Equal(t, int64(1), secondHits.Load())
+}
+
+// Idempotent-method exception extended to HEAD.
+func TestRaceTransport_TransportError_RetriedForHEAD(t *testing.T) {
+	t.Parallel()
+
+	var secondHits atomic.Int64
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		secondHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer second.Close()
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			&mockTransport{
+				name: "rt-error",
+				newRoundTripper: func(_ context.Context, _ string) (http.RoundTripper, error) {
+					return errorRoundTripper{err: errors.New("write: connection reset")}, nil
+				},
+			},
+			delayedTransport("second", second.URL, 50*time.Millisecond),
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodHead, "http://example.com/health", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(1), secondHits.Load(),
+		"HEAD must fall back through a transport-level RoundTrip error")
+}
+
+// 4xx is the server's verdict on the request itself — retrying won't make
+// "your auth is wrong" or "no such resource" any more right. Even for GET,
+// short-circuit on 4xx.
+func TestRaceTransport_FourXX_NotRetried_EvenForGET(t *testing.T) {
+	t.Parallel()
+
+	var firstHits, secondHits atomic.Int64
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		firstHits.Add(1)
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer first.Close()
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		secondHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer second.Close()
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			redirectTransport("first", first.URL),
+			delayedTransport("second", second.URL, 50*time.Millisecond),
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/missing", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, int64(1), firstHits.Load())
+	time.Sleep(150 * time.Millisecond)
+	assert.Equal(t, int64(0), secondHits.Load(),
+		"4xx on GET must not retry — the request, not the transport, is the problem")
+}
+
+func TestIsRetryableMethod(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		method string
+		want   bool
+	}{
+		{http.MethodGet, true},
+		{http.MethodHead, true},
+		{"", true}, // net/http defaults to GET
+		{http.MethodPost, false},
+		{http.MethodPut, false},
+		{http.MethodDelete, false},
+		{http.MethodPatch, false},
+		{http.MethodOptions, false},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, isRetryableMethod(c.method), "method=%q", c.method)
+	}
+}
+
+type errorRoundTripper struct{ err error }
+
+func (e errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, e.err
+}
+
+// Connection-establishment failures must still fall back to the next
+// transport — that's the whole point of racing transports. Only retries
+// after a successful connect are forbidden for non-idempotent methods.
+func TestRaceTransport_ConnectFailure_DoesFallBack(t *testing.T) {
+	t.Parallel()
+
+	var secondHits atomic.Int64
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		secondHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer second.Close()
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			&mockTransport{
+				name: "fail-to-connect",
+				newRoundTripper: func(_ context.Context, _ string) (http.RoundTripper, error) {
+					return nil, errors.New("connect refused")
+				},
+			},
+			redirectTransport("second", second.URL),
+		},
+	)
+
+	req, err := http.NewRequest("POST", "http://example.com/anything", strings.NewReader(`{}`))
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(1), secondHits.Load(),
+		"connect failure on the first transport must fall back to the second — no body has been transmitted")
+}
+
+// redirectTransport returns a Transport whose RoundTripper rewrites the
+// request URL to point at testServerURL, so we can stand up real httptest
+// servers per transport and observe how many times each is hit.
+func redirectTransport(name, testServerURL string) Transport {
+	return &mockTransport{
+		name: name,
+		newRoundTripper: func(_ context.Context, _ string) (http.RoundTripper, error) {
+			return &urlRewritingTransport{target: testServerURL}, nil
+		},
+	}
+}
+
+func delayedTransport(name, testServerURL string, delay time.Duration) Transport {
+	return &mockTransport{
+		name: name,
+		newRoundTripper: func(ctx context.Context, _ string) (http.RoundTripper, error) {
+			select {
+			case <-time.After(delay):
+				return &urlRewritingTransport{target: testServerURL}, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+}
+
+type urlRewritingTransport struct{ target string }
+
+func (u *urlRewritingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	parsed, err := http.NewRequest(req.Method, u.target+req.URL.Path, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	parsed.Header = req.Header.Clone()
+	return http.DefaultTransport.RoundTrip(parsed)
+}
+
 func TestCloneRequest_NilBody(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	require.NoError(t, err)

--- a/race_transport_test.go
+++ b/race_transport_test.go
@@ -299,12 +299,14 @@ func TestRaceTransport_FourXX_NotRetried(t *testing.T) {
 	}))
 	defer second.Close()
 
+	// Delay the second transport's connection so the first wins the race
+	// deterministically. `connected` lets us prove the second transport's
+	// connect goroutine completed before we assert RoundTrip wasn't called.
+	delayed, connected := delayedTransport("second", second.URL, 50*time.Millisecond)
 	rt := newRaceTransport("test", testLog, func(string) {},
 		[]Transport{
 			redirectTransport("first", first.URL),
-			// Delay the second transport's connection so the first wins
-			// the race deterministically.
-			delayedTransport("second", second.URL, 50*time.Millisecond),
+			delayed,
 		},
 	)
 
@@ -318,9 +320,7 @@ func TestRaceTransport_FourXX_NotRetried(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
 		"4xx response from the first transport must be returned to the caller")
 	assert.Equal(t, int64(1), firstHits.Load(), "first transport must see exactly one request")
-	// Wait briefly for the second transport's connect goroutine to settle —
-	// we want to prove RoundTrip wasn't called on it even after it connects.
-	time.Sleep(150 * time.Millisecond)
+	waitForConnected(t, connected)
 	assert.Equal(t, int64(0), secondHits.Load(),
 		"second transport must NOT receive the request — replaying a non-idempotent body is the bug we're guarding against")
 }
@@ -342,10 +342,11 @@ func TestRaceTransport_FiveXX_NotRetried(t *testing.T) {
 	}))
 	defer second.Close()
 
+	delayed, connected := delayedTransport("second", second.URL, 50*time.Millisecond)
 	rt := newRaceTransport("test", testLog, func(string) {},
 		[]Transport{
 			redirectTransport("first", first.URL),
-			delayedTransport("second", second.URL, 50*time.Millisecond),
+			delayed,
 		},
 	)
 
@@ -358,7 +359,7 @@ func TestRaceTransport_FiveXX_NotRetried(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 	assert.Equal(t, int64(1), firstHits.Load())
-	time.Sleep(150 * time.Millisecond)
+	waitForConnected(t, connected)
 	assert.Equal(t, int64(0), secondHits.Load())
 }
 
@@ -382,10 +383,14 @@ func TestRaceTransport_FiveXX_RetriedForGET(t *testing.T) {
 	}))
 	defer second.Close()
 
+	// No explicit waitForConnected here — `secondHits == 1` is itself
+	// implicit synchronization: raceTransport must wait for the delayed
+	// transport's connectResult before issuing the second RoundTrip.
+	delayed, _ := delayedTransport("second", second.URL, 50*time.Millisecond)
 	rt := newRaceTransport("test", testLog, func(string) {},
 		[]Transport{
 			redirectTransport("first", first.URL),
-			delayedTransport("second", second.URL, 50*time.Millisecond),
+			delayed,
 		},
 	)
 
@@ -413,6 +418,7 @@ func TestRaceTransport_TransportError_RetriedForHEAD(t *testing.T) {
 	}))
 	defer second.Close()
 
+	delayed, _ := delayedTransport("second", second.URL, 50*time.Millisecond)
 	rt := newRaceTransport("test", testLog, func(string) {},
 		[]Transport{
 			&mockTransport{
@@ -421,7 +427,7 @@ func TestRaceTransport_TransportError_RetriedForHEAD(t *testing.T) {
 					return errorRoundTripper{err: errors.New("write: connection reset")}, nil
 				},
 			},
-			delayedTransport("second", second.URL, 50*time.Millisecond),
+			delayed,
 		},
 	)
 
@@ -455,10 +461,11 @@ func TestRaceTransport_FourXX_NotRetried_EvenForGET(t *testing.T) {
 	}))
 	defer second.Close()
 
+	delayed, connected := delayedTransport("second", second.URL, 50*time.Millisecond)
 	rt := newRaceTransport("test", testLog, func(string) {},
 		[]Transport{
 			redirectTransport("first", first.URL),
-			delayedTransport("second", second.URL, 50*time.Millisecond),
+			delayed,
 		},
 	)
 
@@ -471,7 +478,7 @@ func TestRaceTransport_FourXX_NotRetried_EvenForGET(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	assert.Equal(t, int64(1), firstHits.Load())
-	time.Sleep(150 * time.Millisecond)
+	waitForConnected(t, connected)
 	assert.Equal(t, int64(0), secondHits.Load(),
 		"4xx on GET must not retry — the request, not the transport, is the problem")
 }
@@ -551,10 +558,19 @@ func redirectTransport(name, testServerURL string) Transport {
 	}
 }
 
-func delayedTransport(name, testServerURL string, delay time.Duration) Transport {
+// delayedTransport returns a Transport whose NewRoundTripper sleeps for
+// `delay` before returning, plus a `connected` channel that is closed once
+// NewRoundTripper has returned (regardless of outcome). Tests that assert
+// the delayed transport's request handler was NOT hit can wait on
+// `connected` to deterministically know the connect goroutine has finished
+// — at which point raceTransport has already observed the connectResult,
+// and either a RoundTrip has fired or it never will.
+func delayedTransport(name, testServerURL string, delay time.Duration) (Transport, <-chan struct{}) {
+	connected := make(chan struct{})
 	return &mockTransport{
 		name: name,
 		newRoundTripper: func(ctx context.Context, _ string) (http.RoundTripper, error) {
+			defer close(connected)
 			select {
 			case <-time.After(delay):
 				return &urlRewritingTransport{target: testServerURL}, nil
@@ -562,13 +578,30 @@ func delayedTransport(name, testServerURL string, delay time.Duration) Transport
 				return nil, ctx.Err()
 			}
 		},
+	}, connected
+}
+
+// waitForConnected blocks until ch is closed or fails the test if the
+// configured grace period elapses first. The grace period is deliberately
+// generous; a hung delayed transport is a test bug, not a race we want to
+// paper over.
+func waitForConnected(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("delayed transport never finished its connect attempt")
 	}
 }
 
 type urlRewritingTransport struct{ target string }
 
 func (u *urlRewritingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	parsed, err := http.NewRequest(req.Method, u.target+req.URL.Path, req.Body)
+	target := u.target + req.URL.Path
+	if req.URL.RawQuery != "" {
+		target += "?" + req.URL.RawQuery
+	}
+	parsed, err := http.NewRequestWithContext(req.Context(), req.Method, target, req.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

`raceTransport` was retrying non-idempotent requests across transports on every 4xx/5xx response and on any post-RoundTrip transport error, replaying request bodies the server had already received. The doc comment has long claimed otherwise:

> *"we don't have to worry about the idempotency of the request because we ultimately try the connections serially"*

— but the implementation never matched. This makes the implementation match the contract.

## Why now

A `POST /peer/verify` request whose server-side dial-back took the full 5s timeout was firing **three** times in production: one 422 + two 404s within ~410ms. Same `peer_route`, three different api pods. The first request's 5xx-equivalent (422 with the verifier deprecating the row) was treated as "retryable" by the loop, and the next two requests landed on a row that no longer existed.

```mermaid
sequenceDiagram
    autonumber
    participant Client as radiance peer client<br/>peer/api.go
    participant RT as raceTransport<br/>kindling/race_transport.go
    participant A as api pod A
    participant B as api pod B
    participant DB as peer_routes

    Client->>RT: POST /peer/verify (route=R)
    RT->>A: clone+RoundTrip (transport 1)
    Note over A: VerifyLive(R) → samizdat dial<br/>blocks 5s on i/o timeout ⚠️
    A->>DB: deprecate(R) (verify failed)
    A-->>RT: 422
    rect rgba(255, 200, 200, 0.3)
        Note over RT: race_transport.go: 422 ≥ 400<br/>treated as retryable 🐛<br/>continue → fire next transport
    end
    RT->>B: clone+RoundTrip (transport 2)
    B->>DB: SELECT route=R AND owner=...
    B-->>RT: 404 lookup miss (R is deprecated)
    rect rgba(255, 200, 200, 0.3)
        Note over RT: 404 ≥ 400 → retry again 🐛
    end
    RT->>B: clone+RoundTrip (transport 3)
    B-->>RT: 404 lookup miss
    RT-->>Client: 404 (final lastResp)
```

## What changes

`isRetryableMethod(method)` returns true only for `GET`/`HEAD`/`""` (matches stdlib `http.Client`'s conservative replay semantics — `PUT`/`DELETE` are technically idempotent per RFC 7231 but the server may have applied the side effect before a transient failure dropped the response, so replaying them is unsafe).

| Method class | Connect failure | RoundTrip error | 4xx | 5xx |
|---|---|---|---|---|
| Non-idempotent (POST/PUT/DELETE/PATCH/OPTIONS) | fall back | **return** | **return** | **return** |
| Idempotent (GET/HEAD) | fall back | fall back | **return** | fall back |

The "5xx-on-GET falls back" branch is what makes raceTransport still useful for `/config-new` polling when one fronting CDN is blocked but others work. 4xx on GET still short-circuits — the request itself is wrong, and replay won't change "auth invalid" or "not found" into 200.

Connect failures are unchanged: no body has been transmitted on a connection that never came up, so retry is always safe.

## Tests

7 race-transport tests added/updated. All 14 pass:

- `FourXX_NotRetried` / `FiveXX_NotRetried` — POST 4xx/5xx returns to caller; second transport not hit (asserted via `secondHits == 0` after a 150ms settle to give its connect goroutine time to complete).
- `FiveXX_RetriedForGET` — GET 502 → falls back → 200.
- `TransportError_RetriedForHEAD` — HEAD with `RoundTrip` returning an error → falls back → 200.
- `FourXX_NotRetried_EvenForGET` — GET 404 short-circuits, second transport not hit.
- `ConnectFailure_DoesFallBack` — connect error falls back regardless of method.
- `IsRetryableMethod` — table test for the predicate.

## Test plan

- [x] `go test ./...` clean
- [x] `go vet ./...` clean
- [ ] Bump `kindling` in `radiance/go.mod` after merge, rebuild, toggle peer-share — should observe exactly one `/peer/verify` request in SigNoz instead of three

🤖 Generated with [Claude Code](https://claude.com/claude-code)