### PR TITLE
race transport: add IdempotentHeader opt-in for POSTs that are safe to replay

### DIFF
--- a/race_transport.go
+++ b/race_transport.go
@@ -12,12 +12,27 @@ import (
 	"time"
 )
 
+// IdempotentHeader is an opt-in marker callers can set on a request to
+// declare it idempotent regardless of HTTP method. raceTransport will
+// then apply the same retry-across-transports behavior to that request
+// that it normally reserves for GET/HEAD: transport-level errors and
+// 5xx responses fall back to the next connected transport.
+//
+// Use this for POST endpoints that are semantically read-only or
+// otherwise safe to replay (e.g., a config-fetch endpoint that returns
+// the same payload regardless of how many times it's called). The
+// header is harmless to leak to the origin — kindling doesn't strip
+// it before sending.
+//
+// Any non-empty value enables the override. Recommended value is "1".
+const IdempotentHeader = "X-Kindling-Idempotent"
+
 // raceTransport is an http.RoundTripper that races *connections* across
 // multiple transports. Connections are established concurrently; the first
 // transport to connect receives the request, and the response is returned
 // to the caller.
 //
-// Retry behavior is method-aware:
+// Retry behavior is method-aware, with a per-request opt-in override:
 //
 //   - For idempotent methods (GET, HEAD), the original retry-across-transports
 //     behavior is preserved: transport-level errors after RoundTrip and 5xx
@@ -37,6 +52,12 @@ import (
 //     here because the side effect may have been applied before a transient
 //     failure dropped the response, matching stdlib http.Client's stricter
 //     view of which methods are safe to replay.
+//
+//   - Callers that know a non-idempotent-by-method request is in fact
+//     safe to replay can opt back into the retry behavior by setting
+//     [IdempotentHeader] on the request. This is intended for POSTs that
+//     wrap idempotent reads (config fetches, status polls) where having
+//     one fronting transport blocked shouldn't cause the call to fail.
 //
 // Connections that fail to establish always fall back to the next transport
 // regardless of method — no body has been transmitted on a connection that
@@ -91,7 +112,7 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		go t.connect(ctx, tr, addr, results)
 	}
 
-	idempotent := isRetryableMethod(req.Method)
+	idempotent := isRetryableMethod(req.Method) || req.Header.Get(IdempotentHeader) != ""
 	var lastResp *http.Response
 	var lastErr error
 

--- a/race_transport_test.go
+++ b/race_transport_test.go
@@ -509,6 +509,128 @@ func (e errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, e.err
 }
 
+// IdempotentHeader is the opt-in escape hatch for non-idempotent-by-method
+// requests that the caller knows are safe to replay (e.g. /config-new POST,
+// which is a read-only fetch dressed up as a POST). When set, the request
+// gets the same retry-across-transports behavior as a GET.
+func TestRaceTransport_IdempotentHeader_RetriesPOSTOn5xx(t *testing.T) {
+	t.Parallel()
+
+	var firstHits, secondHits atomic.Int64
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		firstHits.Add(1)
+		http.Error(w, "blocked", http.StatusBadGateway)
+	}))
+	defer first.Close()
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		secondHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer second.Close()
+
+	delayed, _ := delayedTransport("second", second.URL, 50*time.Millisecond)
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			redirectTransport("first", first.URL),
+			delayed,
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/config-new", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	req.Header.Set(IdempotentHeader, "1")
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"POST tagged idempotent must fall back from 502 (first) to 200 (second)")
+	assert.Equal(t, int64(1), firstHits.Load())
+	assert.Equal(t, int64(1), secondHits.Load())
+}
+
+// Without the opt-in header, POST is single-shot — same as before. Pin
+// this so we don't accidentally widen the override to all POSTs.
+func TestRaceTransport_NoIdempotentHeader_POSTStillSingleShot(t *testing.T) {
+	t.Parallel()
+
+	var firstHits, secondHits atomic.Int64
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		firstHits.Add(1)
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer first.Close()
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		secondHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer second.Close()
+
+	delayed, connected := delayedTransport("second", second.URL, 50*time.Millisecond)
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			redirectTransport("first", first.URL),
+			delayed,
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/peer/verify", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	// Note: IdempotentHeader is intentionally NOT set.
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, int64(1), firstHits.Load())
+	waitForConnected(t, connected)
+	assert.Equal(t, int64(0), secondHits.Load(),
+		"POST without IdempotentHeader must remain single-shot")
+}
+
+// Empty-string header value should NOT enable the override. Treat the
+// header strictly as "non-empty value = idempotent" so accidentally
+// setting an empty string doesn't silently re-enable replay.
+func TestRaceTransport_EmptyIdempotentHeader_POSTStillSingleShot(t *testing.T) {
+	t.Parallel()
+
+	var firstHits, secondHits atomic.Int64
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		firstHits.Add(1)
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer first.Close()
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		secondHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer second.Close()
+
+	delayed, connected := delayedTransport("second", second.URL, 50*time.Millisecond)
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			redirectTransport("first", first.URL),
+			delayed,
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/peer/verify", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	req.Header.Set(IdempotentHeader, "")
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, int64(1), firstHits.Load())
+	waitForConnected(t, connected)
+	assert.Equal(t, int64(0), secondHits.Load())
+}
+
 // Connection-establishment failures must still fall back to the next
 // transport — that's the whole point of racing transports. Only retries
 // after a successful connect are forbidden for non-idempotent methods.


### PR DESCRIPTION
## Summary

Follow-up to #32 — adds \`X-Kindling-Idempotent\` opt-in so callers can flag a non-idempotent-by-method request as safe-to-replay across transports.

## Why

Found by Copilot review on [getlantern/radiance#468](https://github.com/getlantern/radiance/pull/468): \`/config-new\` is actually a POST (\`config/fetcher.go:150\`) even though it's a read-only fetch. With #32 alone, that POST is single-shot — meaning if one fronting CDN is blocked and returns 5xx for the request, the call fails outright instead of falling back to a working transport.

That regresses availability for censored users in exactly the case kindling was built to handle.

## How

| Request shape | Retry-on-5xx-or-RoundTrip-error | 4xx | Connect failure |
|---|---|---|---|
| GET / HEAD | yes (unchanged) | return | fall back |
| POST/PUT/DELETE/PATCH/etc. (default) | **no** (unchanged) | return | fall back |
| Any method + \`X-Kindling-Idempotent: <non-empty>\` | **yes** (new) | return | fall back |

Strictly any non-empty header value enables the override; empty-string is treated as not-set so an accidental \`Set(IdempotentHeader, "")\` doesn't silently re-enable replay.

The header is harmless to leak to the origin and isn't stripped — same convention as the existing \`X-Kindling-App\` and \`X-Kindling-Method\` debug headers.

## Tests

3 new tests:

- \`IdempotentHeader_RetriesPOSTOn5xx\` — POST + header → 502 (first) → 200 (second). Both transports hit.
- \`NoIdempotentHeader_POSTStillSingleShot\` — POST → 500 returns, second transport never hit. Pins the default isn't widened.
- \`EmptyIdempotentHeader_POSTStillSingleShot\` — POST with empty-string header → single-shot. Pins strict-non-empty semantics.

All 17 race_transport tests pass under \`-race\`.

## Follow-up

Once this lands, [radiance#468](https://github.com/getlantern/radiance/pull/468) will be amended to:
1. Bump kindling to the merge SHA of this PR.
2. Set \`req.Header.Set(kindling.IdempotentHeader, "1")\` in \`config/fetcher.go\` for \`/config-new\`.

That keeps \`/config-new\` resilience exactly where it was pre-#32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)