### PR TITLE
Allow callers to plug a custom dialer into the smart strategy

### DIFF
--- a/kindling.go
+++ b/kindling.go
@@ -81,6 +81,12 @@ type kindling struct {
 	// on its default TCPDialer{} / UDPDialer{}.
 	streamDialer transport.StreamDialer
 	packetDialer transport.PacketDialer
+	// deferred holds option work that must run after every other option
+	// has had a chance to mutate the struct. Used by WithProxyless so it
+	// reads streamDialer/packetDialer after WithStreamDialer /
+	// WithPacketDialer have set them, regardless of option order in the
+	// NewKindling call.
+	deferred []func() error
 }
 
 var _ Kindling = (*kindling)(nil)
@@ -96,6 +102,11 @@ func NewKindling(name string, options ...Option) (Kindling, error) {
 	}
 	for _, opt := range options {
 		if err := opt(k); err != nil {
+			return nil, fmt.Errorf("kindling: %w", err)
+		}
+	}
+	for _, fn := range k.deferred {
+		if err := fn(); err != nil {
 			return nil, fmt.Errorf("kindling: %w", err)
 		}
 	}
@@ -259,23 +270,29 @@ func WithAMPCache(c amp.Client) Option {
 }
 
 // WithProxyless enables direct access using the Outline SDK smart dialer,
-// which bypasses DNS-based and SNI-based blocking.
+// which bypasses DNS-based and SNI-based blocking. The smart dialer is
+// constructed after every other option has run, so WithStreamDialer /
+// WithPacketDialer take effect regardless of the order callers pass them
+// to NewKindling.
 func WithProxyless(domains ...string) Option {
 	return func(k *kindling) error {
-		dialer, err := newSmartDialer(k.logWriter, k.streamDialer, k.packetDialer, domains...)
-		if err != nil {
-			return fmt.Errorf("creating smart dialer: %w", err)
-		}
-		k.transports = append(k.transports, &namedTransport{
-			name:         string(TransportSmart),
-			isStreamable: true,
-			newRT: func(ctx context.Context, addr string) (http.RoundTripper, error) {
-				conn, err := dialer.DialStream(ctx, addr)
-				if err != nil {
-					return nil, fmt.Errorf("smart dial: %w", err)
-				}
-				return preconnectedTransport(conn), nil
-			},
+		k.deferred = append(k.deferred, func() error {
+			dialer, err := newSmartDialerFn(k.logWriter, k.streamDialer, k.packetDialer, domains...)
+			if err != nil {
+				return fmt.Errorf("creating smart dialer: %w", err)
+			}
+			k.transports = append(k.transports, &namedTransport{
+				name:         string(TransportSmart),
+				isStreamable: true,
+				newRT: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+					conn, err := dialer.DialStream(ctx, addr)
+					if err != nil {
+						return nil, fmt.Errorf("smart dial: %w", err)
+					}
+					return preconnectedTransport(conn), nil
+				},
+			})
+			return nil
 		})
 		return nil
 	}
@@ -302,6 +319,11 @@ func (t *namedTransport) NewRoundTripper(ctx context.Context, addr string) (http
 
 //go:embed smart_dialer_config.yml
 var configFS embed.FS
+
+// newSmartDialerFn is the package-level constructor used by WithProxyless and
+// NewSmartHTTPTransport. Tests swap it to avoid the strategy's real-network
+// probe during NewKindling's deferred phase.
+var newSmartDialerFn = newSmartDialer
 
 // newSmartDialer constructs an Outline-SDK smart dialer. stream / packet are
 // the base dialers the strategy probes against; either may be nil, in which
@@ -366,7 +388,7 @@ func NewSmartHTTPTransportWithDialer(
 	packet transport.PacketDialer,
 	domains ...string,
 ) (*http.Transport, error) {
-	dialer, err := newSmartDialer(logWriter, stream, packet, domains...)
+	dialer, err := newSmartDialerFn(logWriter, stream, packet, domains...)
 	if err != nil {
 		return nil, err
 	}

--- a/kindling.go
+++ b/kindling.go
@@ -75,6 +75,12 @@ type kindling struct {
 	transports    []Transport
 	panicListener func(string)
 	appName       string
+	// streamDialer/packetDialer override the stdlib net.Dialer that the
+	// Outline SDK smart strategy would otherwise use. Set via
+	// WithStreamDialer / WithPacketDialer. nil leaves the smart dialer
+	// on its default TCPDialer{} / UDPDialer{}.
+	streamDialer transport.StreamDialer
+	packetDialer transport.PacketDialer
 }
 
 var _ Kindling = (*kindling)(nil)
@@ -160,6 +166,35 @@ func WithPanicListener(fn func(string)) Option {
 	}
 }
 
+// WithStreamDialer overrides the TCP dialer used by smart-dialer-based
+// transports (WithProxyless). When unset, the smart dialer uses Outline
+// SDK's default transport.TCPDialer, which dials via the stdlib net.Dialer
+// and so follows the host's routing table — sending packets through any
+// active VPN TUN. Callers that need their connection attempts to bypass
+// a VPN tunnel they themselves serve (radiance is the motivating case)
+// should pass an alternative here.
+func WithStreamDialer(d transport.StreamDialer) Option {
+	return func(k *kindling) error {
+		if d == nil {
+			return fmt.Errorf("stream dialer is nil")
+		}
+		k.streamDialer = d
+		return nil
+	}
+}
+
+// WithPacketDialer is the UDP counterpart to WithStreamDialer. The smart
+// strategy uses UDP for DNS probes that drive strategy selection.
+func WithPacketDialer(d transport.PacketDialer) Option {
+	return func(k *kindling) error {
+		if d == nil {
+			return fmt.Errorf("packet dialer is nil")
+		}
+		k.packetDialer = d
+		return nil
+	}
+}
+
 // WithTransport adds a custom Transport implementation.
 func WithTransport(t Transport) Option {
 	return func(k *kindling) error {
@@ -227,7 +262,7 @@ func WithAMPCache(c amp.Client) Option {
 // which bypasses DNS-based and SNI-based blocking.
 func WithProxyless(domains ...string) Option {
 	return func(k *kindling) error {
-		dialer, err := newSmartDialer(k.logWriter, domains...)
+		dialer, err := newSmartDialer(k.logWriter, k.streamDialer, k.packetDialer, domains...)
 		if err != nil {
 			return fmt.Errorf("creating smart dialer: %w", err)
 		}
@@ -268,16 +303,30 @@ func (t *namedTransport) NewRoundTripper(ctx context.Context, addr string) (http
 //go:embed smart_dialer_config.yml
 var configFS embed.FS
 
-func newSmartDialer(logWriter io.Writer, domains ...string) (transport.StreamDialer, error) {
+// newSmartDialer constructs an Outline-SDK smart dialer. stream / packet are
+// the base dialers the strategy probes against; either may be nil, in which
+// case the stdlib-backed transport.TCPDialer / transport.UDPDialer are used.
+func newSmartDialer(
+	logWriter io.Writer,
+	stream transport.StreamDialer,
+	packet transport.PacketDialer,
+	domains ...string,
+) (transport.StreamDialer, error) {
 	configBytes, err := configFS.ReadFile("smart_dialer_config.yml")
 	if err != nil {
 		return nil, fmt.Errorf("reading smart dialer config: %w", err)
 	}
+	if stream == nil {
+		stream = &transport.TCPDialer{}
+	}
+	if packet == nil {
+		packet = &transport.UDPDialer{}
+	}
 	finder := &smart.StrategyFinder{
 		TestTimeout:  5 * time.Second,
 		LogWriter:    logWriter,
-		StreamDialer: &transport.TCPDialer{},
-		PacketDialer: &transport.UDPDialer{},
+		StreamDialer: stream,
+		PacketDialer: packet,
 	}
 	return finder.NewDialer(context.Background(), domains, configBytes)
 }
@@ -299,9 +348,25 @@ func preconnectedTransport(conn net.Conn) *http.Transport {
 
 // NewSmartHTTPTransport creates an http.Transport using the Outline SDK smart
 // dialer for the given domains. This is a standalone utility that does not
-// require a Kindling instance.
+// require a Kindling instance. The smart dialer's connection attempts go
+// via the stdlib net.Dialer; use NewSmartHTTPTransportWithDialer when those
+// attempts need to bypass an active VPN TUN.
 func NewSmartHTTPTransport(logWriter io.Writer, domains ...string) (*http.Transport, error) {
-	dialer, err := newSmartDialer(logWriter, domains...)
+	return NewSmartHTTPTransportWithDialer(logWriter, nil, nil, domains...)
+}
+
+// NewSmartHTTPTransportWithDialer is NewSmartHTTPTransport plus an override
+// for the base stream / packet dialers the smart strategy probes against.
+// nil dialers fall back to the stdlib-backed defaults. The motivating case
+// is radiance's bypass dialer, which routes connection attempts around its
+// own VPN TUN so kindling traffic doesn't loop through the tunnel.
+func NewSmartHTTPTransportWithDialer(
+	logWriter io.Writer,
+	stream transport.StreamDialer,
+	packet transport.PacketDialer,
+	domains ...string,
+) (*http.Transport, error) {
+	dialer, err := newSmartDialer(logWriter, stream, packet, domains...)
 	if err != nil {
 		return nil, err
 	}

--- a/kindling_test.go
+++ b/kindling_test.go
@@ -2,14 +2,17 @@ package kindling
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/getlantern/domainfront"
 )
 
@@ -86,6 +89,74 @@ func TestNewKindling(t *testing.T) {
 			t.Error("NewKindling(WithTransport(nil)) should return error")
 		}
 	})
+
+	// WithStreamDialer / WithPacketDialer must take effect on WithProxyless
+	// regardless of the order callers pass them. The smart dialer is
+	// constructed in a deferred pass after every option has had a chance to
+	// set streamDialer/packetDialer on the struct — this test guards that
+	// pass from regressing back to in-option construction.
+	t.Run("ProxylessDialerOrderIndependent", func(t *testing.T) {
+		stream := stubStreamDialer{}
+		packet := stubPacketDialer{}
+		cases := []struct {
+			name string
+			opts []Option
+		}{
+			{"dialer-before-proxyless", []Option{
+				WithStreamDialer(stream),
+				WithPacketDialer(packet),
+				WithProxyless("example.com"),
+			}},
+			{"proxyless-before-dialer", []Option{
+				WithProxyless("example.com"),
+				WithStreamDialer(stream),
+				WithPacketDialer(packet),
+			}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var gotStream transport.StreamDialer
+				var gotPacket transport.PacketDialer
+				orig := newSmartDialerFn
+				newSmartDialerFn = func(_ io.Writer, s transport.StreamDialer, p transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
+					gotStream, gotPacket = s, p
+					return stubStreamDialer{}, nil
+				}
+				t.Cleanup(func() { newSmartDialerFn = orig })
+
+				k, err := NewKindling("test", tc.opts...)
+				if err != nil {
+					t.Fatalf("NewKindling() error = %v", err)
+				}
+				if gotStream != stream {
+					t.Errorf("newSmartDialer stream arg = %v; want %v", gotStream, stream)
+				}
+				if gotPacket != packet {
+					t.Errorf("newSmartDialer packet arg = %v; want %v", gotPacket, packet)
+				}
+				ki := k.(*kindling)
+				if len(ki.transports) != 1 || ki.transports[0].Name() != string(TransportSmart) {
+					t.Errorf("transports = %v; want one %q", ki.transports, TransportSmart)
+				}
+			})
+		}
+	})
+}
+
+// stubStreamDialer is a minimal transport.StreamDialer for tests that just
+// need to verify the dialer pointer was plumbed through. The Dial method is
+// not expected to fire — assertions check struct fields, not behavior.
+type stubStreamDialer struct{}
+
+func (stubStreamDialer) DialStream(context.Context, string) (transport.StreamConn, error) {
+	return nil, errors.New("stub: unused")
+}
+
+// stubPacketDialer is the UDP counterpart to stubStreamDialer.
+type stubPacketDialer struct{}
+
+func (stubPacketDialer) DialPacket(context.Context, string) (net.Conn, error) {
+	return nil, errors.New("stub: unused")
 }
 
 func TestLantern(t *testing.T) {


### PR DESCRIPTION
The Outline-SDK smart strategy in \`WithProxyless\` / \`NewSmartHTTPTransport\` was hardcoding \`transport.TCPDialer{}\` / \`transport.UDPDialer{}\` as its base dialers. Both wrap the stdlib \`net.Dialer\`, so on a host with an active VPN TUN claiming the default route the smart-strategy probes (and the eventual production dial) get captured by the TUN and loop through the caller's own tunnel.

Radiance currently works around this by overwriting the returned \`http.Transport\`'s \`DialContext\` with a bypass dial — but that throws away the entire smart strategy. The smart-dialer cost is paid at construction and the strategy is then never actually invoked at request time, so kindling traffic gets neither DPI evasion nor the VPN-loop fix together.

## API additions

Two new options on the Kindling instance:

\`\`\`go
WithStreamDialer(d transport.StreamDialer) Option
WithPacketDialer(d transport.PacketDialer) Option
\`\`\`

And a new standalone helper that mirrors \`NewSmartHTTPTransport\`:

\`\`\`go
NewSmartHTTPTransportWithDialer(
    logWriter io.Writer,
    stream transport.StreamDialer,
    packet transport.PacketDialer,
    domains ...string,
) (*http.Transport, error)
\`\`\`

When the supplied dialer is \`nil\`, \`newSmartDialer\` falls back to the original \`TCPDialer{}\` / \`UDPDialer{}\`, so existing callers (anything using \`WithProxyless(domains...)\` or \`NewSmartHTTPTransport(logWriter, domains...)\` without setting the new options) get exactly today's behavior.

## Why now

Surfaced in a Slack thread from Patrick on 2026-05-15: radiance can't actually feed its bypass dialer into the smart strategy. The workaround it uses (override DialContext post-hoc) suppresses the strategy entirely.

After this PR, radiance can wire \`bypass.DialContext\` into a \`transport.StreamDialer\` adapter and pass it via \`NewSmartHTTPTransportWithDialer\`, restoring the smart strategy on top of bypass.

## Other strategies

| strategy | bypass plumbing | status before this PR |
|---|---|---|
| domainfront | \`domainfront.WithDialer(...)\` | already correct |
| amp | \`amp.WithDialer(...)\` | already correct |
| smart / proxyless | hardcoded \`transport.TCPDialer{}\` | **fixed here** |
| dnstt | private \`dohDialer\` / \`dotDialer\` types | same problem; needs a separate fix in dnstt itself, out of scope here |

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\` (existing tests pass)
- [ ] Follow-up radiance PR rewires \`kindling/smart/client.go\` to use \`NewSmartHTTPTransportWithDialer\` with a \`bypass.DialContext\`-backed \`StreamDialer\` adapter
- [ ] Verify on a real device with VPN active: smart-strategy probes appear in logs (currently they don't because radiance overrides DialContext) and connection counters on the bypass listener increment

🤖 Generated with [Claude Code](https://claude.com/claude-code)