### PR TITLE
Allow callers to override smart_dialer_config.yml

### DIFF
--- a/kindling.go
+++ b/kindling.go
@@ -81,6 +81,9 @@ type kindling struct {
 	// on its default TCPDialer{} / UDPDialer{}.
 	streamDialer transport.StreamDialer
 	packetDialer transport.PacketDialer
+	// smartDialerConfig overrides the embedded smart_dialer_config.yml.
+	// nil falls back to the embedded default.
+	smartDialerConfig []byte
 	// deferred holds option work that must run after every other option
 	// has had a chance to mutate the struct. Used by WithProxyless so it
 	// reads streamDialer/packetDialer after WithStreamDialer /
@@ -206,6 +209,24 @@ func WithPacketDialer(d transport.PacketDialer) Option {
 	}
 }
 
+// WithSmartDialerConfig replaces the embedded smart_dialer_config.yml that
+// drives the Outline SDK strategy probe. Callers that pass a custom
+// StreamDialer typically need this too: the default config lists
+// `system: {}` first under DNS, which makes the strategy fall back to the
+// OS resolver — and outline-sdk then requires the base StreamDialer to be
+// exactly *transport.TCPDialer, rejecting any other type. Supplying a
+// config that omits `system: {}` (using DoH/DoT entries instead) routes
+// every probe through the custom dialer.
+func WithSmartDialerConfig(cfg []byte) Option {
+	return func(k *kindling) error {
+		if len(cfg) == 0 {
+			return fmt.Errorf("smart dialer config is empty")
+		}
+		k.smartDialerConfig = cfg
+		return nil
+	}
+}
+
 // WithTransport adds a custom Transport implementation.
 func WithTransport(t Transport) Option {
 	return func(k *kindling) error {
@@ -277,7 +298,7 @@ func WithAMPCache(c amp.Client) Option {
 func WithProxyless(domains ...string) Option {
 	return func(k *kindling) error {
 		k.deferred = append(k.deferred, func() error {
-			dialer, err := newSmartDialerFn(k.logWriter, k.streamDialer, k.packetDialer, domains...)
+			dialer, err := newSmartDialerFn(k.logWriter, k.smartDialerConfig, k.streamDialer, k.packetDialer, domains...)
 			if err != nil {
 				return fmt.Errorf("creating smart dialer: %w", err)
 			}
@@ -325,18 +346,25 @@ var configFS embed.FS
 // probe during NewKindling's deferred phase.
 var newSmartDialerFn = newSmartDialer
 
-// newSmartDialer constructs an Outline-SDK smart dialer. stream / packet are
-// the base dialers the strategy probes against; either may be nil, in which
-// case the stdlib-backed transport.TCPDialer / transport.UDPDialer are used.
+// newSmartDialer constructs an Outline-SDK smart dialer. config is the YAML
+// strategy spec; nil reads the embedded default. stream / packet are the
+// base dialers the strategy probes against; either may be nil, in which
+// case the stdlib-backed transport.TCPDialer / transport.UDPDialer are
+// used.
 func newSmartDialer(
 	logWriter io.Writer,
+	config []byte,
 	stream transport.StreamDialer,
 	packet transport.PacketDialer,
 	domains ...string,
 ) (transport.StreamDialer, error) {
-	configBytes, err := configFS.ReadFile("smart_dialer_config.yml")
-	if err != nil {
-		return nil, fmt.Errorf("reading smart dialer config: %w", err)
+	configBytes := config
+	if configBytes == nil {
+		var err error
+		configBytes, err = configFS.ReadFile("smart_dialer_config.yml")
+		if err != nil {
+			return nil, fmt.Errorf("reading smart dialer config: %w", err)
+		}
 	}
 	if stream == nil {
 		stream = &transport.TCPDialer{}
@@ -388,7 +416,23 @@ func NewSmartHTTPTransportWithDialer(
 	packet transport.PacketDialer,
 	domains ...string,
 ) (*http.Transport, error) {
-	dialer, err := newSmartDialerFn(logWriter, stream, packet, domains...)
+	return NewSmartHTTPTransportWithConfig(logWriter, nil, stream, packet, domains...)
+}
+
+// NewSmartHTTPTransportWithConfig is NewSmartHTTPTransportWithDialer plus an
+// override for the YAML strategy config. nil reads the embedded default,
+// which lists `system: {}` first under DNS — incompatible with non-default
+// stream dialers, since outline-sdk's smart strategy then requires the base
+// dialer to be *transport.TCPDialer. Pass a config that omits `system: {}`
+// (using DoH/DoT entries) to route every probe through your stream dialer.
+func NewSmartHTTPTransportWithConfig(
+	logWriter io.Writer,
+	config []byte,
+	stream transport.StreamDialer,
+	packet transport.PacketDialer,
+	domains ...string,
+) (*http.Transport, error) {
+	dialer, err := newSmartDialerFn(logWriter, config, stream, packet, domains...)
 	if err != nil {
 		return nil, err
 	}

--- a/kindling.go
+++ b/kindling.go
@@ -425,6 +425,7 @@ func NewSmartHTTPTransportWithDialer(
 // stream dialers, since outline-sdk's smart strategy then requires the base
 // dialer to be *transport.TCPDialer. Pass a config that omits `system: {}`
 // (using DoH/DoT entries) to route every probe through your stream dialer.
+// A non-nil but empty config is rejected, matching WithSmartDialerConfig.
 func NewSmartHTTPTransportWithConfig(
 	logWriter io.Writer,
 	config []byte,
@@ -432,6 +433,9 @@ func NewSmartHTTPTransportWithConfig(
 	packet transport.PacketDialer,
 	domains ...string,
 ) (*http.Transport, error) {
+	if config != nil && len(config) == 0 {
+		return nil, fmt.Errorf("smart dialer config is empty")
+	}
 	dialer, err := newSmartDialerFn(logWriter, config, stream, packet, domains...)
 	if err != nil {
 		return nil, err

--- a/kindling_test.go
+++ b/kindling_test.go
@@ -191,6 +191,73 @@ func TestNewKindling(t *testing.T) {
 	})
 }
 
+// TestNewSmartHTTPTransportWithConfig guards the standalone (non-Kindling)
+// path used by radiance/kindling/smart: the config []byte must reach
+// newSmartDialerFn in the same slot WithSmartDialerConfig sends it through,
+// and the helper must reject a non-nil empty slice — matching the option
+// path's validation so a `make([]byte, 0)` mistake doesn't silently skip
+// the embedded default and hand outline-sdk empty YAML.
+func TestNewSmartHTTPTransportWithConfig(t *testing.T) {
+	t.Run("PlumbsConfigThrough", func(t *testing.T) {
+		customCfg := []byte("dns: []\ntls: []\n")
+		stream := stubStreamDialer{}
+		packet := stubPacketDialer{}
+
+		var gotCfg []byte
+		var gotStream transport.StreamDialer
+		var gotPacket transport.PacketDialer
+		var gotDomains []string
+		orig := newSmartDialerFn
+		newSmartDialerFn = func(_ io.Writer, cfg []byte, s transport.StreamDialer, p transport.PacketDialer, domains ...string) (transport.StreamDialer, error) {
+			gotCfg, gotStream, gotPacket, gotDomains = cfg, s, p, domains
+			return stubStreamDialer{}, nil
+		}
+		t.Cleanup(func() { newSmartDialerFn = orig })
+
+		_, err := NewSmartHTTPTransportWithConfig(io.Discard, customCfg, stream, packet, "example.com")
+		if err != nil {
+			t.Fatalf("NewSmartHTTPTransportWithConfig() error = %v", err)
+		}
+		if string(gotCfg) != string(customCfg) {
+			t.Errorf("config arg = %q; want %q", gotCfg, customCfg)
+		}
+		if gotStream != stream {
+			t.Errorf("stream arg = %v; want %v", gotStream, stream)
+		}
+		if gotPacket != packet {
+			t.Errorf("packet arg = %v; want %v", gotPacket, packet)
+		}
+		if len(gotDomains) != 1 || gotDomains[0] != "example.com" {
+			t.Errorf("domains arg = %v; want [example.com]", gotDomains)
+		}
+	})
+
+	t.Run("NilConfigUsesEmbedded", func(t *testing.T) {
+		var gotCfg []byte
+		orig := newSmartDialerFn
+		newSmartDialerFn = func(_ io.Writer, cfg []byte, _ transport.StreamDialer, _ transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
+			gotCfg = cfg
+			return stubStreamDialer{}, nil
+		}
+		t.Cleanup(func() { newSmartDialerFn = orig })
+
+		_, err := NewSmartHTTPTransportWithConfig(io.Discard, nil, nil, nil, "example.com")
+		if err != nil {
+			t.Fatalf("NewSmartHTTPTransportWithConfig() error = %v", err)
+		}
+		if gotCfg != nil {
+			t.Errorf("config arg = %q; want nil (so newSmartDialer falls back to embedded)", gotCfg)
+		}
+	})
+
+	t.Run("EmptyConfigReturnsError", func(t *testing.T) {
+		_, err := NewSmartHTTPTransportWithConfig(io.Discard, []byte{}, nil, nil, "example.com")
+		if err == nil {
+			t.Error("NewSmartHTTPTransportWithConfig(empty) should return error")
+		}
+	})
+}
+
 // stubStreamDialer is a minimal transport.StreamDialer for tests that just
 // need to verify the dialer pointer was plumbed through. The Dial method is
 // not expected to fire — assertions check struct fields, not behavior.

--- a/kindling_test.go
+++ b/kindling_test.go
@@ -118,7 +118,7 @@ func TestNewKindling(t *testing.T) {
 				var gotStream transport.StreamDialer
 				var gotPacket transport.PacketDialer
 				orig := newSmartDialerFn
-				newSmartDialerFn = func(_ io.Writer, s transport.StreamDialer, p transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
+				newSmartDialerFn = func(_ io.Writer, _ []byte, s transport.StreamDialer, p transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
 					gotStream, gotPacket = s, p
 					return stubStreamDialer{}, nil
 				}
@@ -139,6 +139,54 @@ func TestNewKindling(t *testing.T) {
 					t.Errorf("transports = %v; want one %q", ki.transports, TransportSmart)
 				}
 			})
+		}
+	})
+
+	// WithSmartDialerConfig must reach newSmartDialerFn whether it was set
+	// before or after WithProxyless. Guards the deferred-construction path
+	// from regressing.
+	t.Run("ProxylessConfigOrderIndependent", func(t *testing.T) {
+		customCfg := []byte("dns: []\ntls: []\n")
+		cases := []struct {
+			name string
+			opts []Option
+		}{
+			{"config-before-proxyless", []Option{
+				WithSmartDialerConfig(customCfg),
+				WithProxyless("example.com"),
+			}},
+			{"proxyless-before-config", []Option{
+				WithProxyless("example.com"),
+				WithSmartDialerConfig(customCfg),
+			}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var gotCfg []byte
+				orig := newSmartDialerFn
+				newSmartDialerFn = func(_ io.Writer, cfg []byte, _ transport.StreamDialer, _ transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
+					gotCfg = cfg
+					return stubStreamDialer{}, nil
+				}
+				t.Cleanup(func() { newSmartDialerFn = orig })
+
+				if _, err := NewKindling("test", tc.opts...); err != nil {
+					t.Fatalf("NewKindling() error = %v", err)
+				}
+				if string(gotCfg) != string(customCfg) {
+					t.Errorf("newSmartDialer config arg = %q; want %q", gotCfg, customCfg)
+				}
+			})
+		}
+	})
+
+	t.Run("WithSmartDialerConfig_Empty_ReturnsError", func(t *testing.T) {
+		t.Parallel()
+		if _, err := NewKindling("test", WithSmartDialerConfig(nil)); err == nil {
+			t.Error("NewKindling(WithSmartDialerConfig(nil)) should return error")
+		}
+		if _, err := NewKindling("test", WithSmartDialerConfig([]byte{})); err == nil {
+			t.Error("NewKindling(WithSmartDialerConfig(empty)) should return error")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Follow-up to #34. Lets callers replace the embedded `smart_dialer_config.yml` so a custom `StreamDialer` plumbed via `WithStreamDialer` is actually exercised by the smart strategy.

## Why

The embedded config lists `system: {}` first under DNS. When the Outline-SDK strategy picks the system resolver (which it does whenever the probe path doesn't fail), it enforces this check at `smart/stream_dialer.go:350`:

```go
if resolver == nil {  // resolver == nil means "system: {}" was selected
    if _, ok := f.StreamDialer.(*transport.TCPDialer); !ok {
        return nil, fmt.Errorf("cannot use system resolver with base dialer of type %T", f.StreamDialer)
    }
}
```

So any caller that supplies a `StreamDialer` that isn't exactly `*transport.TCPDialer` — e.g. radiance's bypass dialer, which is a `FuncStreamDialer` wrapping `bypass.DialContext` — sees the smart dialer fail at construction. `findFallback` is then called and errors out with "no fallback was specified" because the kindling config has no `FALLBACK` section.

Semantically this constraint is correct: `system: {}` uses the OS resolver, which routes through OS routing tables. For radiance, that means *through its own VPN TUN* — defeating the entire purpose of bypass. The strategy's type check is honest: "if you're using system DNS, you can't also be doing custom transport routing."

The fix is to let callers swap in a config that omits `system: {}` (using DoH/DoT entries that go through the StreamDialer) when they pass a custom dialer.

## Changes

- `WithSmartDialerConfig([]byte) Option` — overrides the embedded YAML for the `WithProxyless` path. Order-independent with the other dialer options (same deferred-construction pattern as #34).
- `NewSmartHTTPTransportWithConfig(...)` — same override for the standalone helper used by `radiance/kindling/smart`. `NewSmartHTTPTransportWithDialer` is preserved (delegates to the new helper with `nil` config).
- Empty-config validation matching the rest of the option family.
- Test coverage:
  - `ProxylessConfigOrderIndependent` — config supplied before *and* after `WithProxyless` reaches `newSmartDialerFn`.
  - `WithSmartDialerConfig_Empty_ReturnsError` — nil and empty `[]byte` both rejected at option time.

## Test plan

- [x] `go test ./...` passes (existing `ProxylessDialerOrderIndependent` test updated for the new `newSmartDialerFn` signature)
- [ ] Radiance branch using `NewSmartHTTPTransportWithConfig` + a `system`-less YAML resolves the smart strategy through the bypass dialer — to be verified once this lands and radiance bumps the dep

🤖 Generated with [Claude Code](https://claude.com/claude-code)