### PR TITLE
fix: logging when proxyless method fails to start

### DIFF
--- a/kindling.go
+++ b/kindling.go
@@ -3,6 +3,7 @@ package kindling
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -95,7 +96,10 @@ type kindling struct {
 var _ Kindling = (*kindling)(nil)
 
 // NewKindling creates a Kindling instance with the given application name and
-// options. Returns an error if any option fails (e.g. a nil transport argument).
+// options. Returns an error if any option fails synchronously (e.g. a nil
+// transport argument). Deferred initialization failures (such as a failed smart
+// dialer in WithProxyless) are logged as warnings and are only fatal when they
+// leave Kindling with no usable transports.
 func NewKindling(name string, options ...Option) (Kindling, error) {
 	k := &kindling{
 		appName:   name,
@@ -107,10 +111,18 @@ func NewKindling(name string, options ...Option) (Kindling, error) {
 			return nil, fmt.Errorf("kindling: %w", err)
 		}
 	}
+	var deferredErrs []error
 	for _, fn := range k.deferred {
 		if err := fn(); err != nil {
-			k.log.Warn("failed to start proxyless option", slog.Any("error", err))
+			k.log.Warn("deferred option failed to initialize", slog.Any("error", err))
+			deferredErrs = append(deferredErrs, err)
 		}
+	}
+	// A deferred failure is only fatal when it leaves Kindling with no usable
+	// transports. Otherwise the remaining transports can still serve requests,
+	// so we keep going rather than failing the whole instance.
+	if len(deferredErrs) > 0 && len(k.transports) == 0 {
+		return nil, fmt.Errorf("kindling: no transports configured: %w", errors.Join(deferredErrs...))
 	}
 	if k.panicListener == nil {
 		k.panicListener = func(msg string) { k.log.Error(msg) }

--- a/kindling.go
+++ b/kindling.go
@@ -116,9 +116,6 @@ func NewKindling(name string, options ...Option) (Kindling, error) {
 		k.panicListener = func(msg string) { k.log.Error(msg) }
 	}
 
-	if len(k.transports) == 0 {
-		return nil, fmt.Errorf("no transports available")
-	}
 	return k, nil
 }
 

--- a/kindling.go
+++ b/kindling.go
@@ -110,7 +110,7 @@ func NewKindling(name string, options ...Option) (Kindling, error) {
 	}
 	for _, fn := range k.deferred {
 		if err := fn(); err != nil {
-			return nil, fmt.Errorf("kindling: %w", err)
+			k.log.Warn("faied to start proxyless option", slog.Any("error", err))
 		}
 	}
 	if k.panicListener == nil {
@@ -391,7 +391,7 @@ func preconnectedTransport(conn net.Conn) *http.Transport {
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:  20 * time.Second,
+		TLSHandshakeTimeout:   20 * time.Second,
 		ExpectContinueTimeout: 4 * time.Second,
 	}
 }
@@ -447,7 +447,7 @@ func NewSmartHTTPTransportWithConfig(
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:  20 * time.Second,
+		TLSHandshakeTimeout:   20 * time.Second,
 		ExpectContinueTimeout: 4 * time.Second,
 	}, nil
 }

--- a/kindling.go
+++ b/kindling.go
@@ -95,8 +95,7 @@ type kindling struct {
 var _ Kindling = (*kindling)(nil)
 
 // NewKindling creates a Kindling instance with the given application name and
-// options. Returns an error if any option fails (e.g. a nil transport argument
-// or a failed smart dialer initialization).
+// options. Returns an error if any option fails (e.g. a nil transport argument).
 func NewKindling(name string, options ...Option) (Kindling, error) {
 	k := &kindling{
 		appName:   name,
@@ -110,11 +109,15 @@ func NewKindling(name string, options ...Option) (Kindling, error) {
 	}
 	for _, fn := range k.deferred {
 		if err := fn(); err != nil {
-			k.log.Warn("faied to start proxyless option", slog.Any("error", err))
+			k.log.Warn("failed to start proxyless option", slog.Any("error", err))
 		}
 	}
 	if k.panicListener == nil {
 		k.panicListener = func(msg string) { k.log.Error(msg) }
+	}
+
+	if len(k.transports) == 0 {
+		return nil, fmt.Errorf("no transports available")
 	}
 	return k, nil
 }

--- a/kindling_test.go
+++ b/kindling_test.go
@@ -142,6 +142,49 @@ func TestNewKindling(t *testing.T) {
 		}
 	})
 
+	// A deferred (proxyless) init failure must not sink the whole instance
+	// when another transport is configured: kindling degrades to the working
+	// transports rather than failing construction.
+	t.Run("ProxylessFails_OtherTransportSurvives", func(t *testing.T) {
+		orig := newSmartDialerFn
+		newSmartDialerFn = func(_ io.Writer, _ []byte, _ transport.StreamDialer, _ transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
+			return nil, errors.New("probe failed")
+		}
+		t.Cleanup(func() { newSmartDialerFn = orig })
+
+		k, err := NewKindling("test",
+			WithTransport(&namedTransport{name: "stub"}),
+			WithProxyless("example.com"),
+		)
+		if err != nil {
+			t.Fatalf("NewKindling() error = %v; want nil when a non-proxyless transport remains", err)
+		}
+		ki := k.(*kindling)
+		if len(ki.transports) != 1 || ki.transports[0].Name() != "stub" {
+			t.Errorf("transports = %v; want only the surviving %q transport", ki.transports, "stub")
+		}
+	})
+
+	// When the only configured transport is proxyless and its deferred init
+	// fails, kindling has zero usable transports and must surface that at
+	// construction rather than deferring a "no eligible transports" error to
+	// the first request.
+	t.Run("ProxylessFails_NoOtherTransport_ReturnsError", func(t *testing.T) {
+		orig := newSmartDialerFn
+		newSmartDialerFn = func(_ io.Writer, _ []byte, _ transport.StreamDialer, _ transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
+			return nil, errors.New("probe failed")
+		}
+		t.Cleanup(func() { newSmartDialerFn = orig })
+
+		_, err := NewKindling("test", WithProxyless("example.com"))
+		if err == nil {
+			t.Fatal("NewKindling() = nil error; want error when no transports remain")
+		}
+		if !strings.Contains(err.Error(), "probe failed") {
+			t.Errorf("error = %q; want it to wrap the underlying deferred failure", err)
+		}
+	})
+
 	// WithSmartDialerConfig must reach newSmartDialerFn whether it was set
 	// before or after WithProxyless. Guards the deferred-construction path
 	// from regressing.


### PR DESCRIPTION
Previously, if any deferred option (notably `WithProxyless`'s smart-dialer construction) failed to initialize, `NewKindling` would return an error and refuse to start — even when other transports were configured and working.

This changes `NewKindling` to:
- Log each deferred initialization failure as a warning rather than aborting.
- Continue starting Kindling as long as **at least one** transport remains configured.
- Return an error only when deferred failures leave Kindling with **zero** usable transports (errors joined via `errors.Join`), so callers get a clear init-time failure instead of a confusing "no eligible transports for request" error later at request time.

The `NewKindling` doc comment is updated to describe this behavior.