### PR TITLE
feat: race dnstt only as a last resort

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ The techniques integrated include:
 
 The idea is to continually add more techniques as they become available such that all tools have access to the most robust library possible for getting on the network quickly and reliably.
 
+## Transport racing and priorities
+
+Kindling races the configured transports against each other and returns the first usable response. Transports race in priority tiers: every transport in the default tier connects in parallel, and a lower-priority tier is dialed only once every transport in the higher-priority tiers has failed to produce a usable response.
+
+DNS tunneling (`WithDNSTunnel`) is registered as a **last resort**. It keeps working under heavy censorship but is slow and low-throughput, so it is only dialed when the faster transports (domain fronting, proxyless dialing, AMP caching) are all blocked. Custom transports added via `WithTransport` default to the top tier; a transport can opt into a later tier by implementing `Priority() int` (higher numbers race later).
+
 ## Example
 
 ```go

--- a/kindling.go
+++ b/kindling.go
@@ -33,6 +33,18 @@ const (
 	TransportSmart       TransportName = "smart"
 )
 
+const (
+	// priorityDefault is the race tier for transports that don't specify one.
+	// They race in parallel, first connection wins.
+	priorityDefault = 0
+	// priorityLastResort marks a transport raced only after every
+	// default-tier transport has failed to produce a usable response. DNS
+	// tunneling uses it: it keeps working under heavy censorship but is slow
+	// and low-throughput, so it's reserved for when the faster transports are
+	// all blocked rather than letting it compete on equal footing.
+	priorityLastResort = 100
+)
+
 // Kindling creates HTTP clients that race requests across multiple censorship
 // circumvention transports, returning the first successful response.
 type Kindling interface {
@@ -163,6 +175,7 @@ func (k *kindling) ReplaceTransport(name TransportName, rt func(ctx context.Cont
 				maxLength:    tr.MaxLength(),
 				isStreamable: tr.IsStreamable(),
 				reqTimeout:   tr.RequestTimeout(),
+				priority:     priorityOf(tr),
 				newRT:        rt,
 			}
 			return nil
@@ -275,7 +288,10 @@ func WithDomainFronting(c *domainfront.Client) Option {
 	}
 }
 
-// WithDNSTunnel adds DNS tunneling via the provided dnstt.DNSTT.
+// WithDNSTunnel adds DNS tunneling via the provided dnstt.DNSTT. DNS tunneling
+// is raced only as a last resort: it keeps working under heavy censorship but
+// is slow and low-throughput, so the race transport reaches for it only after
+// every faster transport has failed to produce a usable response.
 func WithDNSTunnel(d dnstt.DNSTT) Option {
 	return func(k *kindling) error {
 		if d == nil {
@@ -285,6 +301,7 @@ func WithDNSTunnel(d dnstt.DNSTT) Option {
 			name:         string(TransportDNSTunnel),
 			isStreamable: true,
 			newRT:        d.NewRoundTripper,
+			priority:     priorityLastResort,
 		}
 		if tt, ok := d.(interface{ RequestTimeout() time.Duration }); ok {
 			nt.reqTimeout = tt.RequestTimeout()
@@ -352,12 +369,14 @@ type namedTransport struct {
 	isStreamable bool
 	newRT        func(ctx context.Context, addr string) (http.RoundTripper, error)
 	reqTimeout   time.Duration
+	priority     int
 }
 
 func (t *namedTransport) Name() string                  { return t.name }
 func (t *namedTransport) MaxLength() int                { return t.maxLength }
 func (t *namedTransport) IsStreamable() bool            { return t.isStreamable }
 func (t *namedTransport) RequestTimeout() time.Duration { return t.reqTimeout }
+func (t *namedTransport) Priority() int                 { return t.priority }
 
 func (t *namedTransport) NewRoundTripper(ctx context.Context, addr string) (http.RoundTripper, error) {
 	return t.newRT(ctx, addr)

--- a/race_transport.go
+++ b/race_transport.go
@@ -120,8 +120,11 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	var heldResp *http.Response
 	var heldErr error
 	for i, tier := range tiers {
+		// All transports in a tier share a priority, so the first reports it.
+		// "tier" is the 0-based race order; "priority" is the Priority() value.
 		t.log.Debug("Racing transport tier",
 			"tier", i,
+			"priority", priorityOf(tier[0]),
 			"count", len(tier),
 			"bodyLength", len(bodyBytes),
 		)
@@ -150,6 +153,17 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// All tiers exhausted (or the budget ran out) without a usable response.
 	if heldResp != nil {
 		return heldResp, nil
+	}
+	if ctx.Err() != nil {
+		// The budget ran out before a later tier could be tried, so the
+		// transports were not all exhausted. heldErr already conveys the
+		// timeout (raceTier sets it to a "timed out, last error" wrap or
+		// ctx.Err()); surface it directly rather than claiming every
+		// transport failed.
+		if heldErr != nil {
+			return nil, heldErr
+		}
+		return nil, ctx.Err()
 	}
 	if heldErr != nil {
 		return nil, fmt.Errorf("all transports failed: %w", heldErr)

--- a/race_transport.go
+++ b/race_transport.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sort"
 	"time"
 )
 
@@ -62,6 +63,15 @@ const IdempotentHeader = "X-Kindling-Idempotent"
 // Connections that fail to establish always fall back to the next transport
 // regardless of method — no body has been transmitted on a connection that
 // never came up, so replay risk is zero.
+//
+// Transports are raced in priority tiers (see [transportPriority]). All
+// transports in the lowest-numbered tier race in parallel as described above;
+// a higher-numbered tier is started only once every transport in all
+// lower-numbered tiers has failed to produce a usable response. This reserves
+// slow, low-throughput fallbacks like DNS tunneling for the case where the
+// faster transports are blocked, rather than letting them compete on equal
+// footing. When every transport shares the default priority (the common case),
+// there is a single tier and behavior is unchanged.
 type raceTransport struct {
 	transports    []Transport
 	panicListener func(string)
@@ -99,24 +109,85 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx, cancel := context.WithTimeout(req.Context(), t.requestTimeout(req, eligible))
 	defer cancel()
 
-	t.log.Debug("Racing transports",
-		"count", len(eligible),
-		"bodyLength", len(bodyBytes),
-	)
+	idempotent := isRetryableMethod(req.Method) || req.Header.Get(IdempotentHeader) != ""
+	tiers := groupByPriority(eligible)
 
-	// Connect all eligible transports in parallel. Each goroutine sends
-	// exactly one result, so the channel will receive len(eligible) messages.
-	results := make(chan connectResult, len(eligible))
+	// Race each priority tier in turn. A tier that produces a usable response
+	// (final) returns immediately; otherwise we hold its best fallback (a 5xx
+	// response and/or the last error) and try the next tier. Slow last-resort
+	// transports only get dialed once every faster tier has failed. heldResp /
+	// heldErr carry the best fallback seen across all tiers so far.
+	var heldResp *http.Response
+	var heldErr error
+	for i, tier := range tiers {
+		t.log.Debug("Racing transport tier",
+			"tier", i,
+			"count", len(tier),
+			"bodyLength", len(bodyBytes),
+		)
+		res := t.raceTier(ctx, req, tier, bodyBytes, idempotent)
+		if res.final {
+			drainAndClose(heldResp)
+			return res.resp, res.err
+		}
+		// A 5xx held by this tier supersedes an earlier tier's fallback; an
+		// empty resp leaves the earlier one in place.
+		if res.resp != nil {
+			drainAndClose(heldResp)
+			heldResp = res.resp
+		}
+		if res.err != nil {
+			heldErr = res.err
+		}
+		if ctx.Err() != nil {
+			// The request's time budget is shared across tiers; once it's
+			// spent (timeout or caller cancellation) there's no point dialing
+			// another tier. Fall through to the best result held so far.
+			break
+		}
+	}
+
+	// All tiers exhausted (or the budget ran out) without a usable response.
+	if heldResp != nil {
+		return heldResp, nil
+	}
+	if heldErr != nil {
+		return nil, fmt.Errorf("all transports failed: %w", heldErr)
+	}
+	return nil, errors.New("no transports produced a response")
+}
+
+// tierResult is the outcome of racing a single priority tier. When final is
+// true, resp/err are exactly what RoundTrip should return — either a usable
+// response or a single-shot non-idempotent result. When final is false the
+// tier produced no usable response; resp holds the best fallback (a retryable
+// 5xx) and err the last connection/request error, for RoundTrip to weigh
+// against earlier tiers and carry into the next one. A timeout always reports
+// final=false so RoundTrip can still surface a usable response held by an
+// earlier tier; it stops iterating because the shared ctx is then done.
+type tierResult struct {
+	resp  *http.Response
+	err   error
+	final bool
+}
+
+// raceTier connects every transport in a single priority tier in parallel and
+// applies the method-aware retry policy within that tier. See [raceTransport]
+// for the retry semantics; the only addition is that an exhausted tier returns
+// final=false so RoundTrip can advance to the next tier.
+func (t *raceTransport) raceTier(ctx context.Context, req *http.Request, tier []Transport, bodyBytes []byte, idempotent bool) tierResult {
+	// Each goroutine sends exactly one result, so the channel receives
+	// len(tier) messages.
+	results := make(chan connectResult, len(tier))
 	addr := hostWithPort(req.URL.Host, req.URL.Scheme)
-	for _, tr := range eligible {
+	for _, tr := range tier {
 		go t.connect(ctx, tr, addr, results)
 	}
 
-	idempotent := isRetryableMethod(req.Method) || req.Header.Get(IdempotentHeader) != ""
-	var lastResp *http.Response
-	var lastErr error
+	var heldResp *http.Response
+	var heldErr error
 
-	for remaining := len(eligible); remaining > 0; remaining-- {
+	for remaining := len(tier); remaining > 0; remaining-- {
 		select {
 		case result := <-results:
 			if result.err != nil {
@@ -124,7 +195,7 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 					"name", result.name,
 					"error", result.err,
 				)
-				lastErr = result.err
+				heldErr = result.err
 				continue
 			}
 
@@ -135,7 +206,7 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			if !idempotent {
 				// Single-shot: return whatever happened. Retrying on a non-
 				// idempotent method risks replaying side effects.
-				return resp, err
+				return tierResult{resp: resp, err: err, final: true}
 			}
 
 			if err != nil {
@@ -148,11 +219,8 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 				// err is non-nil (the spec only requires resp == nil when
 				// err == nil for the success direction). Drain + close
 				// defensively so we don't leak the body / connection.
-				if resp != nil {
-					_, _ = io.Copy(io.Discard, resp.Body)
-					_ = resp.Body.Close()
-				}
-				lastErr = err
+				drainAndClose(resp)
+				heldErr = err
 				continue
 			}
 
@@ -165,42 +233,44 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 					"method", req.Method,
 					"status", resp.StatusCode,
 				)
-				if lastResp != nil {
-					_, _ = io.Copy(io.Discard, lastResp.Body)
-					_ = lastResp.Body.Close()
-				}
-				lastResp = resp
-				lastErr = fmt.Errorf("transport %s: http status %d", result.name, resp.StatusCode)
+				drainAndClose(heldResp)
+				heldResp = resp
+				heldErr = fmt.Errorf("transport %s: http status %d", result.name, resp.StatusCode)
 				continue
 			}
 
 			// 2xx, 3xx, or 4xx on an idempotent method: 4xx is the server's
 			// verdict on the request itself, retry won't help. Return.
-			if lastResp != nil {
-				_, _ = io.Copy(io.Discard, lastResp.Body)
-				_ = lastResp.Body.Close()
-			}
-			return resp, nil
+			drainAndClose(heldResp)
+			return tierResult{resp: resp, final: true}
 
 		case <-ctx.Done():
-			if lastResp != nil {
-				return lastResp, nil
+			// Budget spent. Hand back whatever this tier held (if anything) as
+			// non-final so RoundTrip can prefer it or an earlier tier's
+			// fallback; RoundTrip stops iterating because ctx is now done.
+			err := heldErr
+			if err != nil {
+				err = fmt.Errorf("timed out, last error: %w", err)
+			} else if heldResp == nil {
+				err = ctx.Err()
 			}
-			if lastErr != nil {
-				return nil, fmt.Errorf("timed out, last error: %w", lastErr)
-			}
-			return nil, ctx.Err()
+			return tierResult{resp: heldResp, err: err}
 		}
 	}
 
-	// All transports exhausted.
-	if lastResp != nil {
-		return lastResp, nil
+	// Tier exhausted without a usable response; bubble up the best fallback so
+	// RoundTrip can try the next tier (or return it if none succeed).
+	return tierResult{resp: heldResp, err: heldErr}
+}
+
+// drainAndClose drains and closes a response body so the connection can be
+// reused and nothing leaks. Safe to call with a nil response or nil body.
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
 	}
-	if lastErr != nil {
-		return nil, fmt.Errorf("all transports failed: %w", lastErr)
-	}
-	return nil, errors.New("no transports produced a response")
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
 }
 
 // isRetryableMethod reports whether requests with this method are safe to
@@ -240,6 +310,46 @@ func (t *raceTransport) connect(ctx context.Context, tr Transport, addr string, 
 		return
 	}
 	results <- connectResult{rt: rt, name: tr.Name()}
+}
+
+// transportPriority is an optional interface a Transport may implement to
+// influence race ordering. Transports are grouped into tiers by ascending
+// priority, and a tier is raced only after every transport in all
+// lower-numbered tiers has failed to produce a usable response. A transport
+// that does not implement it is treated as priority 0 (raced first). Lower
+// numbers race earlier; reserve higher numbers for slow fallbacks.
+type transportPriority interface {
+	Priority() int
+}
+
+// priorityOf reports a transport's race priority, defaulting to 0 for
+// transports that do not implement transportPriority.
+func priorityOf(tr Transport) int {
+	if p, ok := tr.(transportPriority); ok {
+		return p.Priority()
+	}
+	return priorityDefault
+}
+
+// groupByPriority splits transports into tiers ordered by ascending priority.
+// Transports within a tier race in parallel; tiers are tried in order. Input
+// order is preserved within each tier.
+func groupByPriority(transports []Transport) [][]Transport {
+	byPriority := make(map[int][]Transport)
+	var priorities []int
+	for _, tr := range transports {
+		p := priorityOf(tr)
+		if _, seen := byPriority[p]; !seen {
+			priorities = append(priorities, p)
+		}
+		byPriority[p] = append(byPriority[p], tr)
+	}
+	sort.Ints(priorities)
+	tiers := make([][]Transport, 0, len(priorities))
+	for _, p := range priorities {
+		tiers = append(tiers, byPriority[p])
+	}
+	return tiers
 }
 
 // filterTransports returns only the transports eligible for this request,

--- a/race_transport_test.go
+++ b/race_transport_test.go
@@ -26,6 +26,7 @@ type mockTransport struct {
 	isStreamable    bool
 	maxLength       int
 	reqTimeout      time.Duration
+	priority        int
 	newRoundTripper func(ctx context.Context, addr string) (http.RoundTripper, error)
 }
 
@@ -33,6 +34,7 @@ func (m *mockTransport) Name() string                  { return m.name }
 func (m *mockTransport) IsStreamable() bool            { return m.isStreamable }
 func (m *mockTransport) MaxLength() int                { return m.maxLength }
 func (m *mockTransport) RequestTimeout() time.Duration { return m.reqTimeout }
+func (m *mockTransport) Priority() int                 { return m.priority }
 func (m *mockTransport) NewRoundTripper(ctx context.Context, addr string) (http.RoundTripper, error) {
 	return m.newRoundTripper(ctx, addr)
 }
@@ -505,6 +507,47 @@ func TestIsRetryableMethod(t *testing.T) {
 	}
 }
 
+func TestGroupByPriority(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AllDefault_SingleTier", func(t *testing.T) {
+		t.Parallel()
+		in := []Transport{&mockTransport{name: "a"}, &mockTransport{name: "b"}}
+		tiers := groupByPriority(in)
+		require.Len(t, tiers, 1)
+		assert.Equal(t, []string{"a", "b"}, names(tiers[0]),
+			"a single default tier must preserve input order")
+	})
+
+	t.Run("OrdersTiersAscending_PreservesIntraTierOrder", func(t *testing.T) {
+		t.Parallel()
+		in := []Transport{
+			&mockTransport{name: "dnstt", priority: priorityLastResort},
+			&mockTransport{name: "domainfront"},
+			&mockTransport{name: "amp"},
+			&mockTransport{name: "mid", priority: 50},
+		}
+		tiers := groupByPriority(in)
+		require.Len(t, tiers, 3)
+		assert.Equal(t, []string{"domainfront", "amp"}, names(tiers[0]), "default tier first, input order preserved")
+		assert.Equal(t, []string{"mid"}, names(tiers[1]), "priority 50 in the middle")
+		assert.Equal(t, []string{"dnstt"}, names(tiers[2]), "last-resort tier last")
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, groupByPriority(nil))
+	})
+}
+
+func names(transports []Transport) []string {
+	out := make([]string, len(transports))
+	for i, tr := range transports {
+		out[i] = tr.Name()
+	}
+	return out
+}
+
 type errorRoundTripper struct{ err error }
 
 func (e errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
@@ -668,6 +711,264 @@ func TestRaceTransport_ConnectFailure_DoesFallBack(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, int64(1), secondHits.Load(),
 		"connect failure on the first transport must fall back to the second — no body has been transmitted")
+}
+
+// A last-resort transport (higher Priority) must not even be dialed while a
+// default-tier transport can serve the request. This is the whole point of
+// reserving slow fallbacks like DNS tunneling: they shouldn't compete on equal
+// footing with the fast transports.
+func TestRaceTransport_LastResort_NotDialedWhenDefaultSucceeds(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	var lastResortDialed atomic.Bool
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			&mockTransport{
+				name: "default",
+				newRoundTripper: func(_ context.Context, _ string) (http.RoundTripper, error) {
+					return server.Client().Transport, nil
+				},
+			},
+			&mockTransport{
+				name:     "last-resort",
+				priority: priorityLastResort,
+				newRoundTripper: func(_ context.Context, _ string) (http.RoundTripper, error) {
+					lastResortDialed.Store(true)
+					return server.Client().Transport, nil
+				},
+			},
+		},
+	)
+
+	req, err := http.NewRequest("GET", server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.False(t, lastResortDialed.Load(),
+		"last-resort transport must not be dialed while the default tier succeeds")
+}
+
+// When every default-tier transport fails to produce a usable response, the
+// race must fall back to the last-resort tier — and only then dial it.
+func TestRaceTransport_LastResort_UsedWhenDefaultFails(t *testing.T) {
+	t.Parallel()
+
+	var lastResortHits atomic.Int64
+	lastResortSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		lastResortHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer lastResortSrv.Close()
+
+	// dialSeq records the order in which transports are dialed so we can assert
+	// the last-resort tier is only reached after the default tier.
+	var dialSeq atomic.Int64
+	var defaultDialOrder, lastResortDialOrder atomic.Int64
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			&mockTransport{
+				name: "default",
+				newRoundTripper: func(_ context.Context, _ string) (http.RoundTripper, error) {
+					defaultDialOrder.Store(dialSeq.Add(1))
+					return nil, errors.New("connect refused")
+				},
+			},
+			&mockTransport{
+				name:     "last-resort",
+				priority: priorityLastResort,
+				newRoundTripper: func(_ context.Context, _ string) (http.RoundTripper, error) {
+					lastResortDialOrder.Store(dialSeq.Add(1))
+					return &urlRewritingTransport{target: lastResortSrv.URL}, nil
+				},
+			},
+		},
+	)
+
+	req, err := http.NewRequest("GET", "http://example.com/anything", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(1), lastResortHits.Load(), "last-resort transport should have served the request")
+	assert.Equal(t, int64(1), defaultDialOrder.Load(), "default tier should be dialed first")
+	assert.Equal(t, int64(2), lastResortDialOrder.Load(), "last-resort tier should be dialed only after the default tier")
+}
+
+// A 5xx from the default tier is a retryable failure, so the race must still
+// fall through to the last-resort tier rather than returning the 5xx while a
+// working fallback exists.
+func TestRaceTransport_LastResort_UsedWhenDefaultReturns5xx(t *testing.T) {
+	t.Parallel()
+
+	defaultSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	defer defaultSrv.Close()
+
+	var lastResortHits atomic.Int64
+	lastResortSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		lastResortHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer lastResortSrv.Close()
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			redirectTransport("default", defaultSrv.URL),
+			&mockTransport{
+				name:     "last-resort",
+				priority: priorityLastResort,
+				newRoundTripper: func(_ context.Context, _ string) (http.RoundTripper, error) {
+					return &urlRewritingTransport{target: lastResortSrv.URL}, nil
+				},
+			},
+		},
+	)
+
+	req, err := http.NewRequest("GET", "http://example.com/anything", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(1), lastResortHits.Load(),
+		"a retryable 5xx in the default tier should fall through to the last-resort tier")
+}
+
+// A usable (held) 5xx from an earlier tier must survive a later tier timing
+// out: the request budget is shared, so when the last-resort tier can't beat
+// the deadline we should still return the earlier tier's response rather than
+// a bare context-deadline error.
+func TestRaceTransport_LastResort_TimeoutKeepsEarlierTier5xx(t *testing.T) {
+	t.Parallel()
+
+	defaultSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	defer defaultSrv.Close()
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			redirectTransport("default", defaultSrv.URL),
+			&mockTransport{
+				name:     "last-resort",
+				priority: priorityLastResort,
+				newRoundTripper: func(ctx context.Context, _ string) (http.RoundTripper, error) {
+					// Never connects within the deadline.
+					<-ctx.Done()
+					return nil, ctx.Err()
+				},
+			},
+		},
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://example.com/anything", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err, "must surface the earlier tier's 5xx, not the timeout error")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+}
+
+// A non-idempotent request whose entire default tier fails to *connect* may
+// safely fall through to the last-resort tier: no body has crossed the wire,
+// so there is no replay risk. This is the one path that replays a POST body on
+// a later tier.
+func TestRaceTransport_LastResort_NonIdempotentFallsThroughOnConnectFailure(t *testing.T) {
+	t.Parallel()
+
+	var lastResortHits atomic.Int64
+	lastResortSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		lastResortHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer lastResortSrv.Close()
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			&mockTransport{
+				name: "default",
+				newRoundTripper: func(_ context.Context, _ string) (http.RoundTripper, error) {
+					return nil, errors.New("connect refused")
+				},
+			},
+			&mockTransport{
+				name:     "last-resort",
+				priority: priorityLastResort,
+				newRoundTripper: func(_ context.Context, _ string) (http.RoundTripper, error) {
+					return &urlRewritingTransport{target: lastResortSrv.URL}, nil
+				},
+			},
+		},
+	)
+
+	req, err := http.NewRequest("POST", "http://example.com/anything", strings.NewReader(`{}`))
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(1), lastResortHits.Load(),
+		"a connection failure carries no replay risk, so a non-idempotent request may fall through to the last-resort tier")
+}
+
+// A 5xx on a non-idempotent request is single-shot: it must be returned as-is,
+// NOT retried on the last-resort tier, because the body already crossed the
+// wire and the server may have applied a side effect. Contrast with the
+// idempotent case in TestRaceTransport_LastResort_UsedWhenDefaultReturns5xx.
+func TestRaceTransport_LastResort_NonIdempotent5xxIsSingleShot(t *testing.T) {
+	t.Parallel()
+
+	defaultSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	defer defaultSrv.Close()
+
+	var lastResortDialed atomic.Bool
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			redirectTransport("default", defaultSrv.URL),
+			&mockTransport{
+				name:     "last-resort",
+				priority: priorityLastResort,
+				newRoundTripper: func(_ context.Context, _ string) (http.RoundTripper, error) {
+					lastResortDialed.Store(true)
+					return &urlRewritingTransport{target: defaultSrv.URL}, nil
+				},
+			},
+		},
+	)
+
+	req, err := http.NewRequest("POST", "http://example.com/anything", strings.NewReader(`{}`))
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode, "non-idempotent 5xx is returned as-is")
+	assert.False(t, lastResortDialed.Load(),
+		"a non-idempotent 5xx must not fall through to the last-resort tier — replay risk")
 }
 
 // redirectTransport returns a Transport whose RoundTripper rewrites the

--- a/race_transport_test.go
+++ b/race_transport_test.go
@@ -538,6 +538,35 @@ func TestGroupByPriority(t *testing.T) {
 		t.Parallel()
 		assert.Empty(t, groupByPriority(nil))
 	})
+
+	// A Transport that doesn't implement the optional transportPriority
+	// interface must default to priorityDefault and land in the first tier.
+	t.Run("WithoutPriorityInterface_DefaultsToDefaultTier", func(t *testing.T) {
+		t.Parallel()
+		bare := bareTransport{name: "bare"}
+		assert.Equal(t, priorityDefault, priorityOf(bare),
+			"a Transport that doesn't implement Priority() must default to priorityDefault")
+		tiers := groupByPriority([]Transport{
+			&mockTransport{name: "dnstt", priority: priorityLastResort},
+			bare,
+		})
+		require.Len(t, tiers, 2)
+		assert.Equal(t, []string{"bare"}, names(tiers[0]), "a transport without Priority() lands in the default tier")
+		assert.Equal(t, []string{"dnstt"}, names(tiers[1]))
+	})
+}
+
+// bareTransport implements only the Transport interface — deliberately not the
+// optional transportPriority — so tests can exercise priorityOf's defaulting
+// path. (mockTransport implements Priority(), so it can't.)
+type bareTransport struct{ name string }
+
+func (b bareTransport) Name() string                  { return b.name }
+func (b bareTransport) IsStreamable() bool            { return false }
+func (b bareTransport) MaxLength() int                { return 0 }
+func (b bareTransport) RequestTimeout() time.Duration { return 0 }
+func (b bareTransport) NewRoundTripper(context.Context, string) (http.RoundTripper, error) {
+	return nil, nil
 }
 
 func names(transports []Transport) []string {


### PR DESCRIPTION
Previously the race transport dialed every eligible transport in parallel and the first to connect won, so slow, low-throughput DNS tunneling competed on equal footing with the fast transports (domain fronting, proxyless dialing, AMP caching).

Introduce priority-tiered racing: transports are grouped into tiers by an optional Priority(), and a higher-numbered tier is dialed only after every transport in all lower tiers fails to produce a usable response. dnstt is tagged as a last resort, so it is only reached when the faster transports are all blocked. When every transport shares the default priority (the common case) there is a single tier and behavior is unchanged.

The method-aware retry policy (idempotent retry on 5xx/transport error, single-shot for non-idempotent, connection failures always fall back) is preserved per tier. A timeout in a later tier still surfaces a usable 5xx held by an earlier tier rather than a bare context-deadline error.