### PR TITLE
deps: bump domainfront to h2-capable build (#9)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Jigsaw-Code/outline-sdk/x v0.0.2
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
-	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4
+	github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4 h1:/Q9FJvKPyuXfH6tfA+C+t9/AbvGWs3Yp9iqI74FYvb4=
-github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4/go.mod h1:nsdIvgenGUqPKnRFjkssbfxnV/WYWyC0c/t15qGym/A=
+github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736 h1:Y5d0XP7ammE/ryHj8fPR3JKBYKmOQaYQFN31oF3my7E=
+github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae h1:NMq3K7h3N/usgEtUMQs8WBzvhKKOfBvHo+18pXgtpds=
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
Bumps `github.com/getlantern/domainfront` to the merged
[domainfront#9](https://github.com/getlantern/domainfront/pull/9)
(`v0.0.0-20260419161617-0bff0b2169f4` → `v0.0.0-20260624004218-93591749d736`).

## Why

domainfront#9 makes the fronted round trip **ALPN-aware**: when the CDN edge
negotiates HTTP/2 (CloudFront, Aliyun, …), the request is now framed as HTTP/2
instead of speaking HTTP/1.1 over the h2 connection — which previously failed
with `malformed HTTP response "\x00\x00\x12\x04..."`. kindling fronts through
domainfront, so this fixes h2 edges transparently.

It also carries domainfront's `utls` v1.7.1 → v1.8.2 bump, but that's a no-op
here: kindling already resolves utls to v1.8.2 (via dnstt), and its `go 1.25.0`
directive already satisfies v1.8.x's Go-1.24-native ML-KEM requirement.

## Compatibility

domainfront's public API (`New`, `Config`, `Provider`, `Masquerade`,
`ParseConfig`, `WithConfigURL`) is unchanged — the h2 work was internal to its
round-trip path. So this is a transparent dependency update.

go.mod/go.sum change is limited to the domainfront version. `go build ./...`,
`go vet ./...`, and `go test .` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to ensure system stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->