### PR TITLE
deps: bump domainfront (SNI: default strategy without country code + baked-in SNI)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Jigsaw-Code/outline-sdk/x v0.0.2
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
-	github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736
+	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736 h1:Y5d0XP7ammE/ryHj8fPR3JKBYKmOQaYQFN31oF3my7E=
-github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
+github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b h1:cM+Cwgg6EN279knxvHc4vd3MyNOpZk/49TLlg2F78Rk=
+github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae h1:NMq3K7h3N/usgEtUMQs8WBzvhKKOfBvHo+18pXgtpds=
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
## Summary

Bump `getlantern/domainfront` to `v0.0.0-20260625001429-518c0256669b`, picking up **domainfront#11**.

## What #11 changes

`ExpandedProvider` now resolves each masquerade's SNI so providers can send a **legit** SNI instead of the conspicuous no-SNI every client uses today (the production client passes no country code, which previously left every provider's arbitrary-SNI strategy inert):

- The **`default` frontingsnis strategy applies even with no country code** → akamai sends its arbitrary SNIs (real akamai-customer domains) globally. Validated: 20/20 sampled edges front identically to no-SNI, no regression.
- A **baked-in per-masquerade SNI is preserved** through expansion → lets aliyun pin `www.mobgslb.tbcache.com` (the service domain its edges actually accept).
- The **SNI path verifies the edge cert against the front Domain** (not chain-only) → closes a pre-existing MITM gap; verified it doesn't break akamai (whose arbitrary SNI is a decoy the served cert doesn't cover).

No kindling code changes — `build` + `go test ./...` pass. `go mod tidy` run; `go.mod` + `go.sum` committed together.

## Rollout

Next link in the chain: radiance bumps kindling → lantern bumps radiance. The companion lantern-cloud#2897 sets aliyun's front SNI; both are backward-safe (pre-bump clients omit SNI exactly as today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a direct dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->