### PR TITLE
Bump domainfront for X-Lantern-Fronted-Via provider labeling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Jigsaw-Code/outline-sdk/x v0.0.2
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
-	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b
+	github.com/getlantern/domainfront v0.0.0-20260720182103-06118b2faed5
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b h1:cM+Cwgg6EN279knxvHc4vd3MyNOpZk/49TLlg2F78Rk=
-github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
+github.com/getlantern/domainfront v0.0.0-20260720182103-06118b2faed5 h1:vIXvimju0LD59F/M2OTDs2j/2F0sUgXVaFPzbna7+mE=
+github.com/getlantern/domainfront v0.0.0-20260720182103-06118b2faed5/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae h1:NMq3K7h3N/usgEtUMQs8WBzvhKKOfBvHo+18pXgtpds=
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
Bumps `github.com/getlantern/domainfront` → `v0.0.0-20260720182103-06118b2faed5` to pick up [domainfront#14](https://github.com/getlantern/domainfront/pull/14).

domainfront now sets `X-Lantern-Fronted-Via` to the selected front's `ProviderID` on each fronted request, so the origin (lantern-cloud) can attribute fronted config-fetch traffic **per provider** (akamai / cloudfront / aliyun) instead of bucketing non-Akamai fronts as `direct` in telemetry. Companion to lantern-cloud [#3002](https://github.com/getlantern/lantern-cloud/pull/3002) (maps `aliyun` in `GetSource`).

`go get …@main` + `go mod tidy`; build + tests pass. go.mod/go.sum only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
