### PR TITLE
Bump domainfront to pick up resilient front-retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Jigsaw-Code/outline-sdk/x v0.0.2
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac
-	github.com/getlantern/domainfront v0.0.0-20260720182103-06118b2faed5
+	github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260720182103-06118b2faed5 h1:vIXvimju0LD59F/M2OTDs2j/2F0sUgXVaFPzbna7+mE=
-github.com/getlantern/domainfront v0.0.0-20260720182103-06118b2faed5/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
+github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8 h1:/XB/H1/nRXANtAybB5NjRDjYMfZwR9X0Qs7eGSUGTK4=
+github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae h1:NMq3K7h3N/usgEtUMQs8WBzvhKKOfBvHo+18pXgtpds=
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
Bumps `github.com/getlantern/domainfront` to `db7c158` — [domainfront#15](https://github.com/getlantern/domainfront/pull/15).

## What that PR does

Makes fronted requests resilient to a provider that connects and vets successfully but then won't forward the request (e.g. an Aliyun edge behind the GFW answering `403`/`5xx` or dropping it):

- `doRequest` now treats any response the client deems retryable (default `403` or `>= 500`) as a **front failure** and retries, instead of handing the bad response back to the caller.
- Retries **prefer a different fronting provider** via `frontPool.TakePreferringUntried`, so a ready queue dominated by the misbehaving-but-vetting provider doesn't trap the retries.
- New opt-in `WithRetryableResponse` option to customize the retryable-status predicate.

## This PR

go.mod / go.sum only — no kindling code changes. The new behavior is automatic; the only new exported API is opt-in, so nothing in kindling needs to change. `go build ./...`, `go vet ./...`, and `go test ./...` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->