### PR TITLE
smart: order disorder before split so the strategy can actually dial

### DIFF
--- a/smart_dialer_config.yml
+++ b/smart_dialer_config.yml
@@ -29,5 +29,10 @@ tls:
   - "" # Direct dialer
   - split:1 # TCP stream split at position 1
   - split:2,20*5 # TCP stream split at position 2, followed by 20 blocks of length 5.
-  - split:200|disorder:1 # TCP stream split at position 1, and send the second packet (packet #1) with zero TTL at first.
+  # Split at 200, and send the first packet with a TTL too low to reach the
+  # server so it has to be retransmitted out of order. disorder must come first:
+  # configurl pipes left to right, so the rightmost entry is outermost, and
+  # disorder type-asserts its inner conn to *net.TCPConn — which only the base
+  # dialer returns. Spelled the other way round it never dials.
+  - disorder:1|split:200
   - tlsfrag:1 # TLS Record Fragmentation at position 1


### PR DESCRIPTION
One-line fix to the embedded `smart_dialer_config.yml`: `split:200|disorder:1` → `disorder:1|split:200`.

## Why

`configurl` parses a pipeline left to right, so the **rightmost element is outermost**. The old spelling built `disorder` on top of `split`:

```mermaid
sequenceDiagram
    autonumber
    participant F as strategy finder<br/>outline-sdk smart
    participant D as disorder:1<br/>x/disorder/stream_dialer.go
    participant S as split:200<br/>transport/split/stream_dialer.go
    participant B as base dialer

    Note over F: smart_dialer_config.yml<br/>entry spelled split:200 → disorder:1 ⚠️
    F->>D: DialStream — disorder is outermost
    D->>S: DialStream on its inner dialer
    S->>B: DialStream
    B-->>S: *net.TCPConn
    Note over S: split wraps it in transport.WrapConn
    S-->>D: transport.StreamConn, no longer a *net.TCPConn
    rect rgba(255, 200, 200, 0.3)
        Note over D: innerConn.(*net.TCPConn) fails 🐛<br/>expected base dialer to return TCPConn
    end
    D-->>F: error — strategy silently dropped from the race
```

`disorder.DialStream` type-asserts its inner conn to `*net.TCPConn` so it can set TTL via `sockopt`, but `split.DialStream` returns a `transport.WrapConn`. The assertion can never succeed.

This is not platform- or dialer-specific — it fails with a plain `*transport.TCPDialer`. And because `raceTests` drops a losing strategy without surfacing anything, every caller of `NewSmartHTTPTransport` has been running four TLS strategies where the config lists five, with only a log line to show for it.

outline-sdk's own docs spell it the working way round: `disorder:0|split:123`.

## Verification

Building each strategy over a `*transport.TCPDialer` and dialing a local TLS server:

| strategy | before | after |
|---|---|---|
| `""` | ok | ok |
| `split:1` | ok | ok |
| `split:2,20*5` | ok | ok |
| `split:200\|disorder:1` | **`disorder strategy: expected base dialer to return TCPConn`** | — |
| `disorder:1\|split:200` | — | **ok** |
| `tlsfrag:1` | ok | ok |

`go build ./...` and `go test ./...` pass.

## Notes

`getlantern/radiance` overrides this config (it also has to drop the `system: {}` DNS entry to work with a non-`TCPDialer` base) and is fixed separately in getlantern/radiance#580, which adds test coverage for the ordering invariant and for every strategy across three dialer shapes. Other `NewSmartHTTPTransport` callers get the fix from this PR.

Worth adding a guard test here too — the config is embedded and nothing currently catches a strategy that cannot dial. Happy to add one if you'd prefer it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TLS dialing behavior to correctly simulate out-of-order TCP streams.
  * Improved configuration guidance for applying stream transformations in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->