### PR TITLE
smart: test that every embedded strategy can actually dial

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/smart_dialer_config_test.go
+++ b/smart_dialer_config_test.go
@@ -21,7 +21,6 @@ import (
 
 const strategyTestServerName = "smart-dialer-config-test"
 
-// embeddedStrategies returns the tls strategy list from smart_dialer_config.yml.
 func embeddedStrategies(t *testing.T) []string {
 	t.Helper()
 	raw, err := configFS.ReadFile("smart_dialer_config.yml")
@@ -31,14 +30,14 @@ func embeddedStrategies(t *testing.T) []string {
 		TLS []string `yaml:"tls"`
 	}
 	require.NoError(t, yaml.Unmarshal(raw, &cfg))
-	// Without this the range below would pass by iterating over nothing.
+	// An empty list would make the caller's loop pass vacuously.
 	require.NotEmpty(t, cfg.TLS, "the embedded config lists no tls strategy")
 	return cfg.TLS
 }
 
 // newStrategyTestServer returns a TLS listener's address and a pool trusting its
-// self-signed certificate. Strategies rewrite the stream around TLS record and
-// byte offsets, so exercising them needs a real ClientHello.
+// self-signed certificate. Strategies rewrite the stream around TLS records and
+// write boundaries, so exercising them needs a real ClientHello.
 func newStrategyTestServer(t *testing.T) (string, *x509.CertPool) {
 	t.Helper()
 
@@ -84,10 +83,7 @@ func newStrategyTestServer(t *testing.T) (string, *x509.CertPool) {
 //
 // A strategy that cannot dial at all is invisible in production: the finder
 // races the list and discards whatever fails, so a misspelled entry costs a
-// circumvention technique while everything still appears to work. That is how
-// `split:200|disorder:1` survived — configurl chains left to right, making
-// disorder the outermost wrapper, and disorder type-asserts its inner conn to
-// *net.TCPConn, which the split wrapper underneath it never is.
+// circumvention technique while everything still appears to work.
 func TestEmbeddedStrategiesDial(t *testing.T) {
 	t.Parallel()
 

--- a/smart_dialer_config_test.go
+++ b/smart_dialer_config_test.go
@@ -1,0 +1,122 @@
+package kindling
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+	"github.com/Jigsaw-Code/outline-sdk/x/configurl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const strategyTestServerName = "smart-dialer-config-test"
+
+// embeddedStrategies returns the tls strategy list from smart_dialer_config.yml.
+func embeddedStrategies(t *testing.T) []string {
+	t.Helper()
+	raw, err := configFS.ReadFile("smart_dialer_config.yml")
+	require.NoError(t, err)
+
+	var cfg struct {
+		TLS []string `yaml:"tls"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &cfg))
+	// Without this the range below would pass by iterating over nothing.
+	require.NotEmpty(t, cfg.TLS, "the embedded config lists no tls strategy")
+	return cfg.TLS
+}
+
+// newStrategyTestServer returns a TLS listener's address and a pool trusting its
+// self-signed certificate. Strategies rewrite the stream around TLS record and
+// byte offsets, so exercising them needs a real ClientHello.
+func newStrategyTestServer(t *testing.T) (string, *x509.CertPool) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: strategyTestServerName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{strategyTestServerName},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	roots := x509.NewCertPool()
+	roots.AddCert(cert)
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				conn.(*tls.Conn).HandshakeContext(context.Background())
+			}()
+		}
+	}()
+	return ln.Addr().String(), roots
+}
+
+// TestEmbeddedStrategiesDial builds every strategy in the embedded config and
+// completes a TLS handshake through it.
+//
+// A strategy that cannot dial at all is invisible in production: the finder
+// races the list and discards whatever fails, so a misspelled entry costs a
+// circumvention technique while everything still appears to work. That is how
+// `split:200|disorder:1` survived — configurl chains left to right, making
+// disorder the outermost wrapper, and disorder type-asserts its inner conn to
+// *net.TCPConn, which the split wrapper underneath it never is.
+func TestEmbeddedStrategiesDial(t *testing.T) {
+	t.Parallel()
+
+	addr, roots := newStrategyTestServer(t)
+	for _, strategy := range embeddedStrategies(t) {
+		name := strategy
+		if name == "" {
+			name = "direct"
+		}
+		t.Run(name, func(t *testing.T) {
+			providers := configurl.NewDefaultProviders()
+			providers.StreamDialers.BaseInstance = &transport.TCPDialer{}
+			dialer, err := providers.NewStreamDialer(context.Background(), strategy)
+			require.NoError(t, err, "%q is not a valid outline-sdk config", strategy)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			conn, err := dialer.DialStream(ctx, addr)
+			if !assert.NoError(t, err, "%q cannot dial", strategy) {
+				return
+			}
+			defer conn.Close()
+
+			tlsConn := tls.Client(conn, &tls.Config{
+				ServerName: strategyTestServerName,
+				RootCAs:    roots,
+			})
+			defer tlsConn.Close()
+			assert.NoError(t, tlsConn.HandshakeContext(ctx), "%q cannot complete a handshake", strategy)
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #45, which fixed the `disorder`/`split` ordering but shipped without a regression test.

## Why this is worth a test

A strategy that cannot dial is **invisible in production**. `findTLS` races the whole list and keeps the first one that works, discarding failures — so a misspelled entry costs a circumvention technique while every request still succeeds through the survivors. The reversed `split:200|disorder:1` had been in this config for a long time and only surfaced because someone read an Android log closely.

Nothing in the repo currently catches it: the config is embedded, so a bad entry isn't even a compile error.

## What it does

`TestEmbeddedStrategiesDial` reads the `tls` list straight out of `configFS`, builds each entry through `configurl` over a plain `*transport.TCPDialer`, and completes a TLS handshake with a local self-signed server through it.

Reading the embedded config rather than restating the strategy list matters — a hardcoded copy would drift, and the test would then be guarding a list nobody ships.

The list is asserted non-empty first, so a parse failure or a renamed key can't make the loop pass by iterating over nothing.

## Verification

Reverting the config to the pre-#45 ordering fails the test:

```
--- FAIL: TestEmbeddedStrategiesDial (0.01s)
    --- FAIL: TestEmbeddedStrategiesDial/split:200|disorder:1 (0.00s)
            Messages:   "split:200|disorder:1" cannot dial
```

Restored, the full list passes:

```
--- PASS: TestEmbeddedStrategiesDial/direct
--- PASS: TestEmbeddedStrategiesDial/split:1
--- PASS: TestEmbeddedStrategiesDial/split:2,20*5
--- PASS: TestEmbeddedStrategiesDial/disorder:1|split:200
--- PASS: TestEmbeddedStrategiesDial/tlsfrag:1
```

A loopback dial is sufficient here: `disorder` type-asserts its inner conn to `*net.TCPConn` at `DialStream` time, before any packet moves, so the wrong nesting fails immediately regardless of the network path.

`go build ./...` and `go test ./...` pass.

## Notes

`gopkg.in/yaml.v3` moves from indirect to direct — no version change, it was already in the graph via `outline-sdk/x`. `go mod tidy` run; `go.mod` committed with the test.

`kindling_test.go` shows up under `gofmt -l`, but it does so on `main` too — untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
