### PR TITLE
race: join transport errors instead of keeping only the last

### DIFF
--- a/race_transport.go
+++ b/race_transport.go
@@ -235,6 +235,15 @@ func (t *raceTransport) raceTier(ctx context.Context, req *http.Request, tier []
 			if !idempotent {
 				// Single-shot: return whatever happened. Retrying on a non-
 				// idempotent method risks replaying side effects.
+				//
+				// Named here too, because this branch returns before the
+				// attribution below and POST is exactly where it matters: the
+				// registration call that motivated naming these errors is a
+				// POST, so without this the one path under investigation was
+				// the one path still returning an unattributed error.
+				if err != nil {
+					err = fmt.Errorf("transport %s: %w", result.name, err)
+				}
 				return tierResult{resp: resp, err: err, final: true}
 			}
 
@@ -277,6 +286,28 @@ func (t *raceTransport) raceTier(ctx context.Context, req *http.Request, tier []
 			// Budget spent. Hand back whatever this tier held (if anything) as
 			// non-final so RoundTrip can prefer it or an earlier tier's
 			// fallback; RoundTrip stops iterating because ctx is now done.
+			//
+			// Drain first. select chooses uniformly when several cases are
+			// ready, so a connectResult that has already landed can be passed
+			// over in favour of this branch and its error lost — which defeats
+			// the errors.Is guarantee precisely when a transport failed fast
+			// and the budget expired at about the same moment.
+			//
+			// Non-blocking, and deliberately no RoundTrip on anything drained:
+			// the budget is gone, so a transport that connected is not worth
+			// sending a request through. Only its failure, if any, is news.
+		drain:
+			for {
+				select {
+				case r := <-results:
+					if r.err != nil {
+						heldErr = errors.Join(heldErr, fmt.Errorf("transport %s: %w", r.name, r.err))
+					}
+				default:
+					break drain
+				}
+			}
+
 			err := heldErr
 			if err != nil {
 				// Not "last error" any more: heldErr carries every failure this

--- a/race_transport.go
+++ b/race_transport.go
@@ -140,7 +140,16 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			heldResp = res.resp
 		}
 		if res.err != nil {
-			heldErr = res.err
+			// Across tiers for the same reason as within one. A budget that
+			// expires mid-race returns heldErr alone, so assigning here meant a
+			// timeout was reported as a single strategy's failure while every
+			// other tier's reason — fronted, dnstt, direct — was discarded. That
+			// is what made a smart-dial DNS timeout look like the cause of a
+			// lookup that in fact had several independent failures.
+			//
+			// Joining also fixes errors.Is: a sentinel raised by any tier is now
+			// detectable, where before only the last tier's was.
+			heldErr = errors.Join(heldErr, res.err)
 		}
 		if ctx.Err() != nil {
 			// The request's time budget is shared across tiers; once it's
@@ -157,7 +166,7 @@ func (t *raceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if ctx.Err() != nil {
 		// The budget ran out before a later tier could be tried, so the
 		// transports were not all exhausted. heldErr already conveys the
-		// timeout (raceTier sets it to a "timed out, last error" wrap or
+		// timeout (raceTier sets it to a "timed out, transport errors" wrap or
 		// ctx.Err()); surface it directly rather than claiming every
 		// transport failed.
 		if heldErr != nil {
@@ -209,7 +218,13 @@ func (t *raceTransport) raceTier(ctx context.Context, req *http.Request, tier []
 					"name", result.name,
 					"error", result.err,
 				)
-				heldErr = result.err
+				// Joined, not assigned, and named. Transports in a tier race
+				// concurrently, so assigning kept only whichever lost last and
+				// silently dropped its siblings — and the name lived in
+				// connectResult rather than in the error, so even the survivor
+				// was unattributable unless its own text happened to say which
+				// strategy produced it.
+				heldErr = errors.Join(heldErr, fmt.Errorf("transport %s: %w", result.name, result.err))
 				continue
 			}
 
@@ -234,7 +249,7 @@ func (t *raceTransport) raceTier(ctx context.Context, req *http.Request, tier []
 				// err == nil for the success direction). Drain + close
 				// defensively so we don't leak the body / connection.
 				drainAndClose(resp)
-				heldErr = err
+				heldErr = errors.Join(heldErr, fmt.Errorf("transport %s: %w", result.name, err))
 				continue
 			}
 
@@ -249,7 +264,7 @@ func (t *raceTransport) raceTier(ctx context.Context, req *http.Request, tier []
 				)
 				drainAndClose(heldResp)
 				heldResp = resp
-				heldErr = fmt.Errorf("transport %s: http status %d", result.name, resp.StatusCode)
+				heldErr = errors.Join(heldErr, fmt.Errorf("transport %s: http status %d", result.name, resp.StatusCode))
 				continue
 			}
 
@@ -264,7 +279,9 @@ func (t *raceTransport) raceTier(ctx context.Context, req *http.Request, tier []
 			// fallback; RoundTrip stops iterating because ctx is now done.
 			err := heldErr
 			if err != nil {
-				err = fmt.Errorf("timed out, last error: %w", err)
+				// Not "last error" any more: heldErr carries every failure this
+				// tier collected, so naming one would misdescribe the rest.
+				err = fmt.Errorf("timed out, transport errors: %w", err)
 			} else if heldResp == nil {
 				err = ctx.Err()
 			}

--- a/race_transport_test.go
+++ b/race_transport_test.go
@@ -1304,3 +1304,48 @@ func TestRaceTransport_ErrorsIsFindsAnyTransportsSentinel(t *testing.T) {
 	assert.ErrorIs(t, err, sentinel,
 		"a sentinel from a non-final transport must still be detectable")
 }
+
+// A non-idempotent method returns from the single-shot branch, before the
+// attribution the other paths get. POST is where that matters most: the peer
+// registration call that motivated naming these errors is a POST, so without
+// this the one request under investigation was the one still returning an
+// unattributed error.
+func TestRaceTransport_NamesTransportOnNonIdempotentFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Hijack and close without responding, so RoundTrip fails rather than
+		// returning a status.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("server does not support hijacking")
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		conn.Close()
+	}))
+	defer server.Close()
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			&mockTransport{
+				name: "only-one",
+				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+					return http.DefaultTransport, nil
+				},
+			},
+		},
+	)
+
+	req, err := http.NewRequest("POST", server.URL, strings.NewReader("body"))
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only-one",
+		"a POST failure must still say which transport produced it")
+}

--- a/race_transport_test.go
+++ b/race_transport_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -1213,4 +1214,93 @@ func TestRequestTimeout(t *testing.T) {
 		// budget comes from the eligible "fast" transport instead.
 		assert.Equal(t, 4*time.Minute, rt.requestTimeout(req, eligible))
 	})
+}
+
+// Every transport's failure must survive, not just whichever lost last.
+//
+// Transports in a tier race concurrently and tiers run in sequence, and both
+// loops used to assign heldErr rather than accumulate it. So a caller saw one
+// strategy's error and had no way to know the others had even been tried — which
+// is how a smart-dial DNS timeout came to look like the cause of a lookup that
+// actually had three independent failures.
+func TestRaceTransport_JoinsEveryTransportError(t *testing.T) {
+	t.Parallel()
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			&mockTransport{
+				name: "fast-a", priority: 1,
+				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+					return nil, errors.New("dns timeout")
+				},
+			},
+			&mockTransport{
+				name: "fast-b", priority: 1,
+				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+					return nil, errors.New("connection refused")
+				},
+			},
+			// A separate tier, so this one is only dialed after the first tier
+			// is exhausted — the across-tier path rather than the within-tier one.
+			&mockTransport{
+				name: "slow-c", priority: 2,
+				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+					return nil, errors.New("tls handshake failure")
+				},
+			},
+		},
+	)
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.Error(t, err)
+
+	for _, want := range []string{
+		"dns timeout", "connection refused", "tls handshake failure",
+	} {
+		assert.Contains(t, err.Error(), want, "a transport's failure was dropped")
+	}
+	// And each is attributable. The transport name lived only in connectResult,
+	// so before this the joined text could not say which strategy failed how.
+	for _, want := range []string{"fast-a", "fast-b", "slow-c"} {
+		assert.Contains(t, err.Error(), want, "the failing transport is not named")
+	}
+}
+
+// errors.Is must reach a sentinel raised by ANY transport, not only the last.
+// Callers classify on these — "was this a lack of connectivity or interference?"
+// — and that question cannot be answered from one arbitrary survivor.
+func TestRaceTransport_ErrorsIsFindsAnyTransportsSentinel(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("no route to host")
+
+	rt := newRaceTransport("test", testLog, func(string) {},
+		[]Transport{
+			&mockTransport{
+				name: "first", priority: 1,
+				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+					return nil, fmt.Errorf("dialing: %w", sentinel)
+				},
+			},
+			// Fails later and in a different way, so before joining it was this
+			// error alone that reached the caller and the sentinel was lost.
+			&mockTransport{
+				name: "last", priority: 2,
+				newRoundTripper: func(ctx context.Context, addr string) (http.RoundTripper, error) {
+					return nil, errors.New("something else entirely")
+				},
+			},
+		},
+	)
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel,
+		"a sentinel from a non-final transport must still be detectable")
 }


### PR DESCRIPTION
A peer-share registration failed on a machine whose uplink was down, and the error named **smart dial alone**:

```
Post "https://df.iantem.io/api/v1/peer/register": timed out, last error: smart dial:
  receive DNS message failed: ... lookup cloudflare.net. on [fd7a:115c:a1e0::53]:53: i/o timeout
```

That reads as though smart dial took down the whole lookup. It didn't — it was simply the last strategy to report. Every other tier was tried and its failure thrown away.

## Both loops assigned rather than accumulated

**Within a tier**, transports race concurrently and each failure overwrote the previous:

```go
heldErr = result.err   // whichever lost last wins; siblings discarded
```

**Across tiers**, the same. And when the budget expires mid-race, `RoundTrip` returns `heldErr` directly — so a timeout was reported as one strategy's failure while fronted, dnstt and direct were silently dropped.

## Also: the errors weren't attributable

The transport name lived in `connectResult.name`, not in the error. So even the surviving error could only be identified when its own text happened to say which strategy produced it — which is the only reason "smart dial" was visible above. The 5xx path already wrapped with `transport %s:`; the connect and RoundTrip paths now match.

## Two consequences beyond readability

**`errors.Is` now reaches a sentinel raised by any transport**, not just the last. Callers that classify failures — *"is this a lack of connectivity, or interference?"* — cannot answer that from one arbitrary survivor. That question is why this came up, and it's unanswerable without this change.

**The timeout wrap no longer claims `"last error"`**, which stopped being true the moment `heldErr` carried more than one.

## Tests

Two added, covering the within-tier path, the across-tier path, and `errors.Is`. Verified to fail against the previous behavior:

```
--- FAIL: TestRaceTransport_JoinsEveryTransportError
    a transport's failure was dropped        (x2)
    the failing transport is not named       (x3)
--- FAIL: TestRaceTransport_ErrorsIsFindsAnyTransportsSentinel
    a sentinel from a non-final transport must still be detectable
```

Full suite passes, `gofmt` clean on both changed files. (`kindling_test.go` is gofmt-dirty on `main` already — left alone, not mine.)

## Scope

Deliberately no classification here. Kindling knows only that its own attempts failed, which is equally consistent with "the uplink is down" and "we're blocked" — and guessing wrong in the second direction is harmful. This change makes the evidence available; deciding what it means belongs to the caller, and is the follow-up in radiance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MYMwy9Pu5Ji3xpYK8Nzj3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transport failure reporting by preserving errors from all attempted transports and priority tiers.
  * Transport names are now included in collected error details, including non-idempotent request failures.
  * Timeout messages now accurately describe the full set of transport failures.
  * Pending connection attempts are properly completed when the shared timeout expires.
  * Existing sentinel errors remain detectable through standard error checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->