### PR TITLE
proxyless: search for a strategy on first dial, per domain, bounded

### DIFF
--- a/kindling.go
+++ b/kindling.go
@@ -114,9 +114,10 @@ var _ Kindling = (*kindling)(nil)
 
 // NewKindling creates a Kindling instance with the given application name and
 // options. Returns an error if any option fails synchronously (e.g. a nil
-// transport argument). Deferred initialization failures (such as a failed smart
-// dialer in WithProxyless) are logged as warnings and are only fatal when they
-// leave Kindling with no usable transports.
+// transport argument). Deferred initialization failures are logged as warnings
+// and are only fatal when they leave Kindling with no usable transports. No
+// option does live network work here: WithProxyless registers its transport
+// immediately and searches for a strategy on the first dial.
 func NewKindling(name string, options ...Option) (Kindling, error) {
 	k := &kindling{
 		appName:   name,
@@ -337,13 +338,19 @@ func WithAMPCache(c amp.Client) Option {
 // constructed after every other option has run, so WithStreamDialer /
 // WithPacketDialer take effect regardless of the order callers pass them
 // to NewKindling.
+//
+// The strategy search runs on the first dial, not during NewKindling: it is
+// live network probing that reached ~3.5s on a censored network, stalling
+// callers that start under a deadline (getlantern/engineering#3822).
 func WithProxyless(domains ...string) Option {
 	return func(k *kindling) error {
+		if len(domains) == 0 {
+			return fmt.Errorf("no proxyless domains")
+		}
 		k.deferred = append(k.deferred, func() error {
-			dialer, err := newSmartDialerFn(k.logWriter, k.smartDialerConfig, k.streamDialer, k.packetDialer, domains...)
-			if err != nil {
-				return fmt.Errorf("creating smart dialer: %w", err)
-			}
+			dialer := newLazySmartDialer(
+				k.logWriter, k.smartDialerConfig, k.streamDialer, k.packetDialer, domains,
+			)
 			k.transports = append(k.transports, &namedTransport{
 				name:         string(TransportSmart),
 				isStreamable: true,
@@ -396,8 +403,10 @@ var newSmartDialerFn = newSmartDialer
 // strategy spec; nil reads the embedded default. stream / packet are the
 // base dialers the strategy probes against; either may be nil, in which
 // case the stdlib-backed transport.TCPDialer / transport.UDPDialer are
-// used.
+// used. ctx bounds the strategy search itself, which the Outline finder
+// otherwise limits only per probe.
 func newSmartDialer(
+	ctx context.Context,
 	logWriter io.Writer,
 	config []byte,
 	stream transport.StreamDialer,
@@ -424,7 +433,7 @@ func newSmartDialer(
 		StreamDialer: stream,
 		PacketDialer: packet,
 	}
-	return finder.NewDialer(context.Background(), domains, configBytes)
+	return finder.NewDialer(ctx, domains, configBytes)
 }
 
 // preconnectedTransport creates an http.Transport that uses an already-established
@@ -482,7 +491,9 @@ func NewSmartHTTPTransportWithConfig(
 	if config != nil && len(config) == 0 {
 		return nil, fmt.Errorf("smart dialer config is empty")
 	}
-	dialer, err := newSmartDialerFn(logWriter, config, stream, packet, domains...)
+	searchCtx, cancel := context.WithTimeout(context.Background(), smartSearchTimeout)
+	defer cancel()
+	dialer, err := newSmartDialerFn(searchCtx, logWriter, config, stream, packet, domains...)
 	if err != nil {
 		return nil, err
 	}

--- a/kindling_test.go
+++ b/kindling_test.go
@@ -118,15 +118,20 @@ func TestNewKindling(t *testing.T) {
 				var gotStream transport.StreamDialer
 				var gotPacket transport.PacketDialer
 				orig := newSmartDialerFn
-				newSmartDialerFn = func(_ io.Writer, _ []byte, s transport.StreamDialer, p transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
+				newSmartDialerFn = func(_ context.Context, _ io.Writer, _ []byte, s transport.StreamDialer, p transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
 					gotStream, gotPacket = s, p
-					return stubStreamDialer{}, nil
+					return dialedStreamDialer{}, nil
 				}
 				t.Cleanup(func() { newSmartDialerFn = orig })
 
 				k, err := NewKindling("test", tc.opts...)
 				if err != nil {
 					t.Fatalf("NewKindling() error = %v", err)
+				}
+				// The search is lazy, so the dialers reach it only once
+				// something dials.
+				if err := dialSmart(t, k, "example.com:443"); !errors.Is(err, errStubDialed) {
+					t.Fatalf("dial error = %v; want %v", err, errStubDialed)
 				}
 				if gotStream != stream {
 					t.Errorf("newSmartDialer stream arg = %v; want %v", gotStream, stream)
@@ -142,46 +147,45 @@ func TestNewKindling(t *testing.T) {
 		}
 	})
 
-	// A deferred (proxyless) init failure must not sink the whole instance
-	// when another transport is configured: kindling degrades to the working
-	// transports rather than failing construction.
-	t.Run("ProxylessFails_OtherTransportSurvives", func(t *testing.T) {
-		orig := newSmartDialerFn
-		newSmartDialerFn = func(_ io.Writer, _ []byte, _ transport.StreamDialer, _ transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
+	// A failed strategy search no longer removes the transport at construction:
+	// the search is lazy, so the failure surfaces on the dial that triggered it
+	// and leaves every other transport untouched.
+	t.Run("ProxylessSearchFails_SurfacesOnDial", func(t *testing.T) {
+		stubSearch(t, func(string) (transport.StreamDialer, error) {
 			return nil, errors.New("probe failed")
-		}
-		t.Cleanup(func() { newSmartDialerFn = orig })
+		})
 
 		k, err := NewKindling("test",
 			WithTransport(&namedTransport{name: "stub"}),
 			WithProxyless("example.com"),
 		)
 		if err != nil {
-			t.Fatalf("NewKindling() error = %v; want nil when a non-proxyless transport remains", err)
+			t.Fatalf("NewKindling() error = %v; want nil", err)
 		}
 		ki := k.(*kindling)
-		if len(ki.transports) != 1 || ki.transports[0].Name() != "stub" {
-			t.Errorf("transports = %v; want only the surviving %q transport", ki.transports, "stub")
+		if len(ki.transports) != 2 {
+			t.Fatalf("transports = %v; want the stub plus the proxyless transport", ki.transports)
+		}
+		if err := dialSmart(t, k, "example.com:443"); err == nil || !strings.Contains(err.Error(), "probe failed") {
+			t.Errorf("dial error = %v; want it to wrap the search failure", err)
 		}
 	})
 
-	// When the only configured transport is proxyless and its deferred init
-	// fails, kindling has zero usable transports and must surface that at
-	// construction rather than deferring a "no eligible transports" error to
-	// the first request.
-	t.Run("ProxylessFails_NoOtherTransport_ReturnsError", func(t *testing.T) {
-		orig := newSmartDialerFn
-		newSmartDialerFn = func(_ io.Writer, _ []byte, _ transport.StreamDialer, _ transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
+	// A proxyless-only instance whose search fails now constructs successfully
+	// and reports the failure per dial. That is the point of deferring the
+	// search: a domain blocked at first contact recovers on a later dial
+	// instead of forcing the caller to rebuild kindling.
+	t.Run("ProxylessOnly_SearchFails_ConstructsAndFailsPerDial", func(t *testing.T) {
+		stubSearch(t, func(string) (transport.StreamDialer, error) {
 			return nil, errors.New("probe failed")
-		}
-		t.Cleanup(func() { newSmartDialerFn = orig })
+		})
 
-		_, err := NewKindling("test", WithProxyless("example.com"))
-		if err == nil {
-			t.Fatal("NewKindling() = nil error; want error when no transports remain")
+		k, err := NewKindling("test", WithProxyless("example.com"))
+		if err != nil {
+			t.Fatalf("NewKindling() error = %v; want construction to succeed", err)
 		}
-		if !strings.Contains(err.Error(), "probe failed") {
-			t.Errorf("error = %q; want it to wrap the underlying deferred failure", err)
+		if err := dialSmart(t, k, "example.com:443"); err == nil || !strings.Contains(err.Error(), "probe failed") {
+			t.Errorf("dial error = %v; want it to wrap the search failure", err)
 		}
 	})
 
@@ -207,14 +211,18 @@ func TestNewKindling(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				var gotCfg []byte
 				orig := newSmartDialerFn
-				newSmartDialerFn = func(_ io.Writer, cfg []byte, _ transport.StreamDialer, _ transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
+				newSmartDialerFn = func(_ context.Context, _ io.Writer, cfg []byte, _ transport.StreamDialer, _ transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
 					gotCfg = cfg
-					return stubStreamDialer{}, nil
+					return dialedStreamDialer{}, nil
 				}
 				t.Cleanup(func() { newSmartDialerFn = orig })
 
-				if _, err := NewKindling("test", tc.opts...); err != nil {
+				k, err := NewKindling("test", tc.opts...)
+				if err != nil {
 					t.Fatalf("NewKindling() error = %v", err)
+				}
+				if err := dialSmart(t, k, "example.com:443"); !errors.Is(err, errStubDialed) {
+					t.Fatalf("dial error = %v; want %v", err, errStubDialed)
 				}
 				if string(gotCfg) != string(customCfg) {
 					t.Errorf("newSmartDialer config arg = %q; want %q", gotCfg, customCfg)
@@ -248,7 +256,7 @@ func (s *stubDNSTT) NewRoundTripper(ctx context.Context, addr string) (http.Roun
 func (s *stubDNSTT) Close() error { return nil }
 
 func (s *stubDNSTT) RequestTimeout() time.Duration { return s.reqTimeout }
-func (s *stubDNSTT) MaxLength() int               { return s.maxLength }
+func (s *stubDNSTT) MaxLength() int                { return s.maxLength }
 
 func TestWithDNSTunnelOverrides(t *testing.T) {
 	t.Parallel()
@@ -332,7 +340,7 @@ func TestNewSmartHTTPTransportWithConfig(t *testing.T) {
 		var gotPacket transport.PacketDialer
 		var gotDomains []string
 		orig := newSmartDialerFn
-		newSmartDialerFn = func(_ io.Writer, cfg []byte, s transport.StreamDialer, p transport.PacketDialer, domains ...string) (transport.StreamDialer, error) {
+		newSmartDialerFn = func(_ context.Context, _ io.Writer, cfg []byte, s transport.StreamDialer, p transport.PacketDialer, domains ...string) (transport.StreamDialer, error) {
 			gotCfg, gotStream, gotPacket, gotDomains = cfg, s, p, domains
 			return stubStreamDialer{}, nil
 		}
@@ -359,7 +367,7 @@ func TestNewSmartHTTPTransportWithConfig(t *testing.T) {
 	t.Run("NilConfigUsesEmbedded", func(t *testing.T) {
 		var gotCfg []byte
 		orig := newSmartDialerFn
-		newSmartDialerFn = func(_ io.Writer, cfg []byte, _ transport.StreamDialer, _ transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
+		newSmartDialerFn = func(_ context.Context, _ io.Writer, cfg []byte, _ transport.StreamDialer, _ transport.PacketDialer, _ ...string) (transport.StreamDialer, error) {
 			gotCfg = cfg
 			return stubStreamDialer{}, nil
 		}

--- a/proxyless.go
+++ b/proxyless.go
@@ -1,0 +1,159 @@
+package kindling
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+)
+
+// smartSearchTimeout bounds one strategy search. The Outline finder applies
+// only a per-probe TestTimeout, so without an overall bound a wedged probe set
+// pins the search goroutine for the life of the process.
+const smartSearchTimeout = 60 * time.Second
+
+// lazySmartDialer dials through one Outline smart dialer per domain, each built
+// by a strategy search that starts on first dial rather than at construction.
+//
+// One search per domain rather than one covering all of them: the search is
+// conjunctive, so a single dialer given several domains succeeds only if one
+// strategy unblocks every one of them, and a domain that is blocked outright
+// then takes the reachable ones down with it.
+type lazySmartDialer struct {
+	// domains is in caller order and deduplicated; domains[0] is the fallback
+	// for addresses that match no configured domain.
+	domains  []string
+	searches map[string]*smartSearch
+}
+
+func newLazySmartDialer(
+	logWriter io.Writer,
+	config []byte,
+	stream transport.StreamDialer,
+	packet transport.PacketDialer,
+	domains []string,
+) *lazySmartDialer {
+	l := &lazySmartDialer{searches: make(map[string]*smartSearch, len(domains))}
+	for _, domain := range domains {
+		if _, seen := l.searches[domain]; seen {
+			continue
+		}
+		l.domains = append(l.domains, domain)
+		l.searches[domain] = &smartSearch{
+			build: func() (transport.StreamDialer, error) {
+				ctx, cancel := context.WithTimeout(context.Background(), smartSearchTimeout)
+				defer cancel()
+				return newSmartDialerFn(ctx, logWriter, config, stream, packet, domain)
+			},
+		}
+	}
+	return l
+}
+
+// DialStream waits for the search covering addr's host, bounded by ctx, then
+// dials through the dialer it produced.
+func (l *lazySmartDialer) DialStream(ctx context.Context, addr string) (transport.StreamConn, error) {
+	search, err := l.searchFor(addr)
+	if err != nil {
+		return nil, err
+	}
+	dialer, err := search.await(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return dialer.DialStream(ctx, addr)
+}
+
+// searchFor returns the search for addr's host, falling back to the first
+// configured domain: a dialer tuned for a sibling host is a better guess than
+// failing the dial outright.
+func (l *lazySmartDialer) searchFor(addr string) (*smartSearch, error) {
+	if len(l.domains) == 0 {
+		return nil, errors.New("no proxyless domains configured")
+	}
+	host := addr
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		host = h
+	}
+	if search, ok := l.searches[host]; ok {
+		return search, nil
+	}
+	return l.searches[l.domains[0]], nil
+}
+
+// smartSearch owns one domain's strategy search. Searches are single-flight:
+// callers arriving while one runs join it instead of starting a second.
+type smartSearch struct {
+	build func() (transport.StreamDialer, error)
+
+	mu       sync.Mutex
+	dialer   transport.StreamDialer
+	inFlight *pendingSearch
+}
+
+// pendingSearch is one attempt at building a domain's dialer. dialer and err
+// are written before done is closed, so a caller that has received from done
+// may read them without the lock.
+type pendingSearch struct {
+	done   chan struct{}
+	dialer transport.StreamDialer
+	err    error
+}
+
+// await returns the domain's dialer, starting a search on first use and joining
+// one already under way otherwise. ctx bounds only the wait — the search runs to
+// completion on its own goroutine, so work a caller gave up on still serves
+// whoever comes next.
+func (s *smartSearch) await(ctx context.Context) (transport.StreamDialer, error) {
+	dialer, pending := s.begin()
+	if dialer != nil {
+		return dialer, nil
+	}
+	select {
+	case <-pending.done:
+		return pending.dialer, pending.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// begin hands the search back rather than waiting on it, so the caller that
+// starts one can abandon it on its own context just as a joiner can.
+func (s *smartSearch) begin() (transport.StreamDialer, *pendingSearch) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.dialer != nil {
+		return s.dialer, nil
+	}
+	if s.inFlight == nil {
+		s.inFlight = &pendingSearch{done: make(chan struct{})}
+		go s.run(s.inFlight)
+	}
+	return nil, s.inFlight
+}
+
+// run remembers a successful search and deliberately forgets a failed one, so a
+// domain blocked at first contact recovers on a later dial without a restart.
+func (s *smartSearch) run(pending *pendingSearch) {
+	defer func() {
+		if r := recover(); r != nil {
+			pending.dialer, pending.err = nil, fmt.Errorf("smart dialer search panicked: %v", r)
+		}
+		if pending.err == nil && pending.dialer == nil {
+			pending.err = errors.New("smart dialer search produced no dialer")
+		}
+		s.mu.Lock()
+		s.inFlight = nil
+		if pending.err == nil {
+			s.dialer = pending.dialer
+		}
+		s.mu.Unlock()
+		close(pending.done)
+	}()
+	pending.dialer, pending.err = s.build()
+}

--- a/proxyless_test.go
+++ b/proxyless_test.go
@@ -3,6 +3,7 @@ package kindling
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -53,15 +54,18 @@ func stubSearch(t *testing.T, fn func(domain string) (transport.StreamDialer, er
 	t.Helper()
 	orig := newSmartDialerFn
 	newSmartDialerFn = func(
-		ctx context.Context,
+		_ context.Context,
 		_ io.Writer,
 		_ []byte,
 		_ transport.StreamDialer,
 		_ transport.PacketDialer,
 		domains ...string,
 	) (transport.StreamDialer, error) {
+		// An error rather than t.Errorf and a fallthrough: indexing domains[0]
+		// on an empty slice would panic and bury whatever really went wrong.
 		if len(domains) != 1 {
-			t.Errorf("search domains = %v; want exactly one (searches are per domain)", domains)
+			return nil, fmt.Errorf("search got %d domains, want exactly 1 (searches are per domain): %v",
+				len(domains), domains)
 		}
 		return fn(domains[0])
 	}
@@ -167,17 +171,23 @@ func TestWithProxyless_SearchIsSingleFlight(t *testing.T) {
 	}
 
 	const dialers = 8
+	dispatched := make(chan struct{}, dialers)
 	var wg sync.WaitGroup
 	errs := make([]error, dialers)
 	for i := range dialers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			dispatched <- struct{}{}
 			errs[i] = dialSmart(t, k, "example.com:443")
 		}()
 	}
-	// Let every dial arrive while the one search is still running.
-	time.Sleep(100 * time.Millisecond)
+	// Wait for every dial to be dispatched rather than sleeping a fixed span.
+	// The assertion holds either way: a dial that lands after the search has
+	// finished gets the cached dialer, so it still starts no second search.
+	for range dialers {
+		<-dispatched
+	}
 	close(release)
 	wg.Wait()
 

--- a/proxyless_test.go
+++ b/proxyless_test.go
@@ -1,0 +1,260 @@
+package kindling
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+)
+
+// errStubDialed marks "the strategy search finished and its dialer was used",
+// which is otherwise indistinguishable from a search failure at the call site.
+var errStubDialed = errors.New("stub: dialed")
+
+type dialedStreamDialer struct{}
+
+func (dialedStreamDialer) DialStream(context.Context, string) (transport.StreamConn, error) {
+	return nil, errStubDialed
+}
+
+var errNoSmartTransport = errors.New("no smart transport registered")
+
+// dialSmart drives the proxyless transport, which is what triggers its lazy
+// strategy search, and returns the resulting error. Safe to call from a
+// spawned goroutine — it reports failures as errors rather than via t.Fatalf.
+func dialSmart(t *testing.T, k Kindling, addr string) error {
+	t.Helper()
+	return dialSmartCtx(t, context.Background(), k, addr)
+}
+
+func dialSmartCtx(t *testing.T, ctx context.Context, k Kindling, addr string) error {
+	t.Helper()
+	for _, tr := range k.(*kindling).transports {
+		if tr.Name() == string(TransportSmart) {
+			_, err := tr.NewRoundTripper(ctx, addr)
+			return err
+		}
+	}
+	return errNoSmartTransport
+}
+
+// stubSearch swaps the strategy search for fn and restores it after the test.
+//
+// A test whose fn blocks must ensure every search it started has entered fn
+// before returning: an abandoned search keeps running, and the restore here
+// would otherwise race its read of the seam.
+func stubSearch(t *testing.T, fn func(domain string) (transport.StreamDialer, error)) {
+	t.Helper()
+	orig := newSmartDialerFn
+	newSmartDialerFn = func(
+		ctx context.Context,
+		_ io.Writer,
+		_ []byte,
+		_ transport.StreamDialer,
+		_ transport.PacketDialer,
+		domains ...string,
+	) (transport.StreamDialer, error) {
+		if len(domains) != 1 {
+			t.Errorf("search domains = %v; want exactly one (searches are per domain)", domains)
+		}
+		return fn(domains[0])
+	}
+	t.Cleanup(func() { newSmartDialerFn = orig })
+}
+
+// A censored network turns the strategy search into seconds of live probing.
+// Construction must not pay for it: callers on a start deadline (the iOS
+// NEPacketTunnelProvider, ~7.5s) were killed mid-search — engineering#3822.
+func TestWithProxyless_SlowSearchDoesNotBlockConstruction(t *testing.T) {
+	const searchDelay = 3 * time.Second
+	stubSearch(t, func(string) (transport.StreamDialer, error) {
+		time.Sleep(searchDelay)
+		return dialedStreamDialer{}, nil
+	})
+
+	start := time.Now()
+	k, err := NewKindling("test", WithProxyless("example.com"))
+	if err != nil {
+		t.Fatalf("NewKindling() error = %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > searchDelay/4 {
+		t.Fatalf("NewKindling() took %v with a %v search; want it to return without waiting", elapsed, searchDelay)
+	}
+
+	// The search still has to produce a working dialer, just off the
+	// construction path.
+	if err := dialSmart(t, k, "example.com:443"); !errors.Is(err, errStubDialed) {
+		t.Errorf("dial error = %v; want %v", err, errStubDialed)
+	}
+}
+
+// A caller that cannot wait out the search must be able to give up on its own
+// context instead of inheriting the search's timeline.
+func TestWithProxyless_DialRespectsCallerDeadline(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{})
+	stubSearch(t, func(string) (transport.StreamDialer, error) {
+		close(entered)
+		<-release
+		return dialedStreamDialer{}, nil
+	})
+
+	k, err := NewKindling("test", WithProxyless("example.com"))
+	if err != nil {
+		t.Fatalf("NewKindling() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	if err := dialSmartCtx(t, ctx, k, "example.com:443"); !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("dial error = %v; want %v", err, context.DeadlineExceeded)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("dial took %v; want it bounded by the caller's 50ms deadline", elapsed)
+	}
+
+	// The abandoned search runs on regardless — that is the design. Let it
+	// finish before the seam is restored.
+	<-entered
+	close(release)
+}
+
+// The search is conjunctive, so one dialer covering several domains fails
+// whenever any single domain is blocked. Searching per domain keeps a blocked
+// api.getiantem.org from taking a reachable df.iantem.io down with it.
+func TestWithProxyless_BlockedDomainDoesNotSinkSibling(t *testing.T) {
+	stubSearch(t, func(domain string) (transport.StreamDialer, error) {
+		if domain == "blocked.example" {
+			return nil, errors.New("probe failed")
+		}
+		return dialedStreamDialer{}, nil
+	})
+
+	k, err := NewKindling("test", WithProxyless("reachable.example", "blocked.example"))
+	if err != nil {
+		t.Fatalf("NewKindling() error = %v", err)
+	}
+
+	if err := dialSmart(t, k, "reachable.example:443"); !errors.Is(err, errStubDialed) {
+		t.Errorf("reachable dial error = %v; want %v", err, errStubDialed)
+	}
+	if err := dialSmart(t, k, "blocked.example:443"); err == nil || !strings.Contains(err.Error(), "probe failed") {
+		t.Errorf("blocked dial error = %v; want the search failure", err)
+	}
+}
+
+// Concurrent dials must share one search: a search probes the whole strategy
+// space, and several at once overran the iOS extension's 50 MB jetsam cap.
+func TestWithProxyless_SearchIsSingleFlight(t *testing.T) {
+	var searches atomic.Int32
+	release := make(chan struct{})
+	stubSearch(t, func(string) (transport.StreamDialer, error) {
+		searches.Add(1)
+		<-release
+		return dialedStreamDialer{}, nil
+	})
+
+	k, err := NewKindling("test", WithProxyless("example.com"))
+	if err != nil {
+		t.Fatalf("NewKindling() error = %v", err)
+	}
+
+	const dialers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, dialers)
+	for i := range dialers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = dialSmart(t, k, "example.com:443")
+		}()
+	}
+	// Let every dial arrive while the one search is still running.
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := searches.Load(); got != 1 {
+		t.Errorf("searches = %d; want 1 shared by all %d dials", got, dialers)
+	}
+	for i, err := range errs {
+		if !errors.Is(err, errStubDialed) {
+			t.Errorf("dial %d error = %v; want %v", i, err, errStubDialed)
+		}
+	}
+}
+
+// A successful search is reused; a failed one is deliberately forgotten so a
+// domain blocked at first contact recovers without rebuilding kindling.
+func TestWithProxyless_FailedSearchRetriesAndSuccessCaches(t *testing.T) {
+	var searches atomic.Int32
+	stubSearch(t, func(string) (transport.StreamDialer, error) {
+		if searches.Add(1) <= 2 {
+			return nil, errors.New("probe failed")
+		}
+		return dialedStreamDialer{}, nil
+	})
+
+	k, err := NewKindling("test", WithProxyless("example.com"))
+	if err != nil {
+		t.Fatalf("NewKindling() error = %v", err)
+	}
+
+	for i := range 2 {
+		if err := dialSmart(t, k, "example.com:443"); err == nil || !strings.Contains(err.Error(), "probe failed") {
+			t.Fatalf("dial %d error = %v; want the search failure", i, err)
+		}
+	}
+	if got := searches.Load(); got != 2 {
+		t.Fatalf("searches after two failed dials = %d; want 2 (a failure must not be cached)", got)
+	}
+
+	for i := range 2 {
+		if err := dialSmart(t, k, "example.com:443"); !errors.Is(err, errStubDialed) {
+			t.Fatalf("dial %d after recovery: error = %v; want %v", i, err, errStubDialed)
+		}
+	}
+	if got := searches.Load(); got != 3 {
+		t.Errorf("searches after recovery = %d; want 3 (a success must be cached)", got)
+	}
+}
+
+// An address with no matching search falls back to the first configured
+// domain's dialer rather than failing outright.
+func TestWithProxyless_UnknownHostUsesFirstDomain(t *testing.T) {
+	var searched []string
+	var mu sync.Mutex
+	stubSearch(t, func(domain string) (transport.StreamDialer, error) {
+		mu.Lock()
+		searched = append(searched, domain)
+		mu.Unlock()
+		return dialedStreamDialer{}, nil
+	})
+
+	k, err := NewKindling("test", WithProxyless("first.example", "second.example"))
+	if err != nil {
+		t.Fatalf("NewKindling() error = %v", err)
+	}
+	if err := dialSmart(t, k, "unlisted.example:443"); !errors.Is(err, errStubDialed) {
+		t.Fatalf("dial error = %v; want %v", err, errStubDialed)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(searched) != 1 || searched[0] != "first.example" {
+		t.Errorf("searched = %v; want only [first.example]", searched)
+	}
+}
+
+func TestWithProxyless_NoDomains_ReturnsError(t *testing.T) {
+	if _, err := NewKindling("test", WithProxyless()); err == nil {
+		t.Error("NewKindling(WithProxyless()) = nil error; want an error")
+	}
+}


### PR DESCRIPTION
## Why

`WithProxyless` ran the Outline strategy search inline, in `NewKindling`'s deferred pass (`kindling.go:131-137` runs the deferred list synchronously; `kindling.go:342` is the only entry in it). That search is live network probing. On a censored network it took **~3.5s**, and it lands on any caller that constructs kindling under a start deadline.

In getlantern/engineering#3822 that caller is the iOS `NEPacketTunnelProvider`, which iOS kills at ~7.5s — so CN users on 9.1.18 never got a tunnel at all, 76 connect attempts, never once `Connected`.

Three properties made it fatal:

1. **No overall deadline.** `finder.NewDialer(context.Background(), ...)` with only a per-probe `TestTimeout: 5s`. One slow probe can eat the whole budget.
2. **The search is conjunctive across hosts.** `WithProxyless("df.iantem.io", "api.getiantem.org")` builds one dialer for both, so a strategy wins only if it unblocks *both* — a blocked `api.getiantem.org` was taking a reachable `df.iantem.io` down with it. radiance already documents this hazard one layer up and works around it by giving each host its own dialer (`kindling/smart`, `NewHTTPClientWithSmartTransport`); this call site never got the same treatment.
3. It runs **twice** for a CN client, because radiance rebuilds kindling to disable AMP.

## What changed

- The search runs on the **first dial**, on its own goroutine, single-flight. A caller's context bounds only its wait, so a caller that gives up leaves the search running for whoever comes next.
- **One search per domain** instead of one covering all of them.
- `newSmartDialer` takes a `context.Context`, so the search has an overall deadline rather than only the finder's per-probe timeout.

## Contract change — please review deliberately

A failed search no longer removes the transport at construction, so **`NewKindling` no longer returns an error when proxyless is the only transport and its search fails**. The failure surfaces per dial instead, and a failed search is deliberately not cached, so a domain blocked at first contact recovers without rebuilding kindling.

This affects radiance's staging path (`kindling/client.go:180`), which previously got a constructor error and will now get an instance whose dials fail. That reads as an improvement — it is retryable where the old behavior was terminal — but it is a real behavior change, not an accident.

## Tests

`proxyless_test.go` is new. The one that encodes the bug:

```
TestWithProxyless_SlowSearchDoesNotBlockConstruction
```

gives the search a 3s delay and fails if `NewKindling` waits on it — the regression is otherwise unreproducible outside a censored network. Also covers caller-deadline bounding, per-domain isolation (blocked domain does not sink a reachable sibling), single-flight sharing, failed-search retry vs successful-search caching, and unknown-host fallback.

`go test ./... -race` is clean, 3x for flakiness.

## Ships with

- getlantern/radiance — settle the country transport policy before the first build, and gate connect on config readiness
- getlantern/lantern — take the backend bootstrap off the `startTunnel` deadline

Merge order is kindling → radiance → lantern, with a `go mod tidy` at each bump.

Refs getlantern/engineering#3822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg


---

**Stack:** getlantern/kindling#48 → getlantern/radiance#607 → getlantern/lantern#8993 (merge in that order, `go mod tidy` at each bump).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proxyless transport setup now completes without waiting for strategy discovery.
  * Smart dialing starts when first needed and supports separate domain-specific searches.
  * Caller cancellation and timeouts are honored during dialing.
  * Successful searches are cached, while failed searches can be retried.
  * Unknown hosts fall back to the first configured domain.

* **Bug Fixes**
  * Improved handling of missing proxyless domains and strategy discovery errors.
  * Prevented slow or blocked domain searches from affecting other domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->